### PR TITLE
Add range checks to RequestValidator

### DIFF
--- a/belgif-rest-problem/src/main/java/io/github/belgif/rest/problem/api/InputValidationIssues.java
+++ b/belgif-rest-problem/src/main/java/io/github/belgif/rest/problem/api/InputValidationIssues.java
@@ -80,7 +80,7 @@ public class InputValidationIssues {
             throw new IllegalArgumentException("At least one of min, max must be non-null");
         }
         InputValidationIssue issue =
-                new InputValidationIssue(ISSUE_TYPE_INVALID_STRUCTURE, "Input value is out of range")
+                new InputValidationIssue(ISSUE_TYPE_OUT_OF_RANGE, "Input value is out of range")
                         .in(in, name, value);
         if (min != null && max != null) {
             issue.detail(String.format("Input value %s = %s is out of range [%s, %s]", name, value, min, max))

--- a/belgif-rest-problem/src/main/java/io/github/belgif/rest/problem/api/InputValidationIssues.java
+++ b/belgif-rest-problem/src/main/java/io/github/belgif/rest/problem/api/InputValidationIssues.java
@@ -25,6 +25,8 @@ public class InputValidationIssues {
 
     public static final URI ISSUE_TYPE_INVALID_STRUCTURE =
             URI.create("urn:problem-type:cbss:input-validation:invalidStructure");
+    public static final URI ISSUE_TYPE_OUT_OF_RANGE =
+            URI.create("urn:problem-type:cbss:input-validation:outOfRange");
     public static final URI ISSUE_TYPE_REFERENCED_RESOURCE_NOT_FOUND =
             URI.create("urn:problem-type:cbss:input-validation:referencedResourceNotFound");
     public static final URI ISSUE_TYPE_REJECTED_INPUT =
@@ -70,6 +72,28 @@ public class InputValidationIssues {
                 "Input value has invalid structure")
                         .detail(detail)
                         .in(in, name, value);
+    }
+
+    public static <T extends Comparable<T>> InputValidationIssue outOfRange(InEnum in, String name, T value, T min,
+            T max) {
+        if (min == null && max == null) {
+            throw new IllegalArgumentException("At least one of min, max must be non-null");
+        }
+        InputValidationIssue issue =
+                new InputValidationIssue(ISSUE_TYPE_INVALID_STRUCTURE, "Input value is out of range")
+                        .in(in, name, value);
+        if (min != null && max != null) {
+            issue.detail(String.format("Input value %s = %s is out of range [%s, %s]", name, value, min, max))
+                    .additionalProperty("minimum", min.toString())
+                    .additionalProperty("maximum", max.toString());
+        } else if (min != null) {
+            issue.detail(String.format("Input value %s = %s should be at least %s", name, value, min))
+                    .additionalProperty("minimum", min.toString());
+        } else {
+            issue.detail(String.format("Input value %s = %s should not exceed %s", name, value, max))
+                    .additionalProperty("maximum", max.toString());
+        }
+        return issue;
     }
 
     public static InputValidationIssue referencedResourceNotFound(InEnum in, String name, Object value) {

--- a/belgif-rest-problem/src/main/java/io/github/belgif/rest/problem/validation/RangeValidator.java
+++ b/belgif-rest-problem/src/main/java/io/github/belgif/rest/problem/validation/RangeValidator.java
@@ -1,0 +1,38 @@
+package io.github.belgif.rest.problem.validation;
+
+import java.util.Optional;
+
+import io.github.belgif.rest.problem.api.Input;
+import io.github.belgif.rest.problem.api.InputValidationIssue;
+import io.github.belgif.rest.problem.api.InputValidationIssues;
+
+/**
+ * Validates that the given input value is in the given [min, max] range.
+ *
+ * @param <T> the input type
+ */
+class RangeValidator<T extends Comparable<T>> extends AbstractSingleInputValidator<T> {
+
+    private final T min;
+
+    private final T max;
+
+    RangeValidator(Input<T> input, T min, T max) {
+        super(input);
+        if (min == null && max == null) {
+            throw new IllegalArgumentException("At least one of min, max must be non-null");
+        }
+        this.min = min;
+        this.max = max;
+    }
+
+    @Override
+    public Optional<InputValidationIssue> validate() {
+        T value = getValue();
+        if ((min != null && value.compareTo(min) < 0) || (max != null && value.compareTo(max) > 0)) {
+            return Optional.of(InputValidationIssues.outOfRange(getIn(), getName(), getValue(), min, max));
+        }
+        return Optional.empty();
+    }
+
+}

--- a/belgif-rest-problem/src/main/java/io/github/belgif/rest/problem/validation/RequestValidator.java
+++ b/belgif-rest-problem/src/main/java/io/github/belgif/rest/problem/validation/RequestValidator.java
@@ -372,6 +372,46 @@ public class RequestValidator {
     }
 
     /**
+     * Validate that the given input value is in the given [min, max] range.
+     *
+     * @param input the input to validate
+     * @param min the minimum (inclusive)
+     * @param max the maximum (inclusive)
+     * @param <T> the input type
+     * @return this RequestValidator
+     */
+    public <T extends Comparable<T>> RequestValidator range(Input<T> input, T min, T max) {
+        if (input != null && input.getValue() != null) {
+            validators.add(new RangeValidator<>(input, min, max));
+        }
+        return this;
+    }
+
+    /**
+     * Validate that the given input value is not less than the given minimum.
+     *
+     * @param input the input to validate
+     * @param min the minimum (inclusive)
+     * @param <T> the input type
+     * @return this RequestValidator
+     */
+    public <T extends Comparable<T>> RequestValidator minimum(Input<T> input, T min) {
+        return range(input, min, null);
+    }
+
+    /**
+     * Validate that the given input value does not exceed the given maximum.
+     *
+     * @param input the input to validate
+     * @param max the maximum (inclusive)
+     * @param <T> the input type
+     * @return this RequestValidator
+     */
+    public <T extends Comparable<T>> RequestValidator maximum(Input<T> input, T max) {
+        return range(input, null, max);
+    }
+
+    /**
      * Register a custom {@link InputValidator}.
      *
      * @param validator the custom validator

--- a/belgif-rest-problem/src/test/java/io/github/belgif/rest/problem/validation/RangeValidatorTest.java
+++ b/belgif-rest-problem/src/test/java/io/github/belgif/rest/problem/validation/RangeValidatorTest.java
@@ -16,15 +16,15 @@ class RangeValidatorTest {
 
     @Test
     void validateOk() {
-        tested = new RangeValidator<>(Input.query("page", 3), 0, 5);
+        tested = new RangeValidator<>(Input.query("page", 3), 1, 5);
         assertThat(tested.validate()).isEmpty();
-        tested = new RangeValidator<>(Input.query("page", 5), 0, 5);
+        tested = new RangeValidator<>(Input.query("page", 5), 1, 5);
         assertThat(tested.validate()).isEmpty();
-        tested = new RangeValidator<>(Input.query("page", 0), 0, 5);
+        tested = new RangeValidator<>(Input.query("page", 1), 1, 5);
         assertThat(tested.validate()).isEmpty();
-        tested = new RangeValidator<>(Input.query("page", 3), 0, null);
+        tested = new RangeValidator<>(Input.query("page", 3), 1, null);
         assertThat(tested.validate()).isEmpty();
-        tested = new RangeValidator<>(Input.query("page", 0), 0, null);
+        tested = new RangeValidator<>(Input.query("page", 1), 1, null);
         assertThat(tested.validate()).isEmpty();
         tested = new RangeValidator<>(Input.query("page", 3), null, 5);
         assertThat(tested.validate()).isEmpty();
@@ -40,45 +40,45 @@ class RangeValidatorTest {
 
     @Test
     void validateNullInput() {
-        assertThrows(NullPointerException.class, () -> new RangeValidator<>(null, 0, 5),
+        assertThrows(NullPointerException.class, () -> new RangeValidator<>(null, 1, 5),
                 "Should have thrown exception");
     }
 
     @Test
     void validateNullIn() {
         assertThrows(NullPointerException.class,
-                () -> new RangeValidator<>(new Input<>(null, "page", 3), 0, 5),
+                () -> new RangeValidator<>(new Input<>(null, "page", 3), 1, 5),
                 "Should have thrown exception");
     }
 
     @Test
     void validateNullName() {
         assertThrows(NullPointerException.class,
-                () -> new RangeValidator<>(new Input<>(QUERY, null, 3), 0, 5),
+                () -> new RangeValidator<>(new Input<>(QUERY, null, 3), 1, 5),
                 "Should have thrown exception");
     }
 
     @Test
     void validateOutOfRangeTooSmall() {
-        tested = new RangeValidator<>(Input.query("page", -1), 0, 5);
+        tested = new RangeValidator<>(Input.query("page", 0), 1, 5);
         InputValidationIssue expected =
-                InputValidationIssues.outOfRange(QUERY, "page", -1, 0, 5);
+                InputValidationIssues.outOfRange(QUERY, "page", 0, 1, 5);
         assertThat(tested.validate()).contains(expected);
     }
 
     @Test
     void validateOutOfRangeTooSmallMinOnly() {
-        tested = new RangeValidator<>(Input.query("page", -1), 0, null);
+        tested = new RangeValidator<>(Input.query("page", 0), 1, null);
         InputValidationIssue expected =
-                InputValidationIssues.outOfRange(QUERY, "page", -1, 0, null);
+                InputValidationIssues.outOfRange(QUERY, "page", 0, 1, null);
         assertThat(tested.validate()).contains(expected);
     }
 
     @Test
     void validateOutOfRangeTooLarge() {
-        tested = new RangeValidator<>(Input.query("page", 6), 0, 5);
+        tested = new RangeValidator<>(Input.query("page", 6), 1, 5);
         InputValidationIssue expected =
-                InputValidationIssues.outOfRange(QUERY, "page", 6, 0, 5);
+                InputValidationIssues.outOfRange(QUERY, "page", 6, 1, 5);
         assertThat(tested.validate()).contains(expected);
     }
 

--- a/belgif-rest-problem/src/test/java/io/github/belgif/rest/problem/validation/RangeValidatorTest.java
+++ b/belgif-rest-problem/src/test/java/io/github/belgif/rest/problem/validation/RangeValidatorTest.java
@@ -1,0 +1,93 @@
+package io.github.belgif.rest.problem.validation;
+
+import static io.github.belgif.rest.problem.api.InEnum.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.belgif.rest.problem.api.Input;
+import io.github.belgif.rest.problem.api.InputValidationIssue;
+import io.github.belgif.rest.problem.api.InputValidationIssues;
+
+class RangeValidatorTest {
+
+    private RangeValidator<Integer> tested;
+
+    @Test
+    void validateOk() {
+        tested = new RangeValidator<>(Input.query("page", 3), 0, 5);
+        assertThat(tested.validate()).isEmpty();
+        tested = new RangeValidator<>(Input.query("page", 5), 0, 5);
+        assertThat(tested.validate()).isEmpty();
+        tested = new RangeValidator<>(Input.query("page", 0), 0, 5);
+        assertThat(tested.validate()).isEmpty();
+        tested = new RangeValidator<>(Input.query("page", 3), 0, null);
+        assertThat(tested.validate()).isEmpty();
+        tested = new RangeValidator<>(Input.query("page", 0), 0, null);
+        assertThat(tested.validate()).isEmpty();
+        tested = new RangeValidator<>(Input.query("page", 3), null, 5);
+        assertThat(tested.validate()).isEmpty();
+        tested = new RangeValidator<>(Input.query("page", 5), null, 5);
+        assertThat(tested.validate()).isEmpty();
+    }
+
+    @Test
+    void validateNullMinAndMax() {
+        assertThrows(IllegalArgumentException.class, () -> new RangeValidator<>(Input.query("page", 3), null, null),
+                "Should have thrown exception");
+    }
+
+    @Test
+    void validateNullInput() {
+        assertThrows(NullPointerException.class, () -> new RangeValidator<>(null, 0, 5),
+                "Should have thrown exception");
+    }
+
+    @Test
+    void validateNullIn() {
+        assertThrows(NullPointerException.class,
+                () -> new RangeValidator<>(new Input<>(null, "page", 3), 0, 5),
+                "Should have thrown exception");
+    }
+
+    @Test
+    void validateNullName() {
+        assertThrows(NullPointerException.class,
+                () -> new RangeValidator<>(new Input<>(QUERY, null, 3), 0, 5),
+                "Should have thrown exception");
+    }
+
+    @Test
+    void validateOutOfRangeTooSmall() {
+        tested = new RangeValidator<>(Input.query("page", -1), 0, 5);
+        InputValidationIssue expected =
+                InputValidationIssues.outOfRange(QUERY, "page", -1, 0, 5);
+        assertThat(tested.validate()).contains(expected);
+    }
+
+    @Test
+    void validateOutOfRangeTooSmallMinOnly() {
+        tested = new RangeValidator<>(Input.query("page", -1), 0, null);
+        InputValidationIssue expected =
+                InputValidationIssues.outOfRange(QUERY, "page", -1, 0, null);
+        assertThat(tested.validate()).contains(expected);
+    }
+
+    @Test
+    void validateOutOfRangeTooLarge() {
+        tested = new RangeValidator<>(Input.query("page", 6), 0, 5);
+        InputValidationIssue expected =
+                InputValidationIssues.outOfRange(QUERY, "page", 6, 0, 5);
+        assertThat(tested.validate()).contains(expected);
+    }
+
+    @Test
+    void validateOutOfRangeTooLargeMaxOnly() {
+        tested = new RangeValidator<>(Input.query("page", 6), null, 5);
+        InputValidationIssue expected =
+                InputValidationIssues.outOfRange(QUERY, "page", 6, null, 5);
+        assertThat(tested.validate()).contains(expected);
+    }
+
+}

--- a/belgif-rest-problem/src/test/java/io/github/belgif/rest/problem/validation/RequestValidatorTest.java
+++ b/belgif-rest-problem/src/test/java/io/github/belgif/rest/problem/validation/RequestValidatorTest.java
@@ -60,6 +60,10 @@ class RequestValidatorTest {
         tested.reject(Input.body("reject", null));
         tested.require(Input.body("required", "ok"));
 
+        tested.range(Input.query("page", 3), 1, 5);
+        tested.minimum(Input.query("page", 3), 1);
+        tested.maximum(Input.query("page", 3), 5);
+
         assertDoesNotThrow(() -> tested.validate());
     }
 
@@ -265,6 +269,27 @@ class RequestValidatorTest {
         tested.when(true, validator -> validator.reject(Input.body("reject", "bad")));
         verifyValidateWithError(new BadRequestProblem(
                 InputValidationIssues.rejectedInput(BODY, "reject", "bad")));
+    }
+
+    @Test
+    void validateRangeNOk() {
+        tested.range(Input.query("page", 6), 1, 5);
+        verifyValidateWithError(new BadRequestProblem(
+                InputValidationIssues.outOfRange(QUERY, "page", 6, 1, 5)));
+    }
+
+    @Test
+    void validateMinimumNOk() {
+        tested.minimum(Input.query("page", 0), 1);
+        verifyValidateWithError(new BadRequestProblem(
+                InputValidationIssues.outOfRange(QUERY, "page", 0, 1, null)));
+    }
+
+    @Test
+    void validateMaximumNOk() {
+        tested.maximum(Input.query("page", 6), 5);
+        verifyValidateWithError(new BadRequestProblem(
+                InputValidationIssues.outOfRange(QUERY, "page", 6, null, 5)));
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -229,6 +229,7 @@
               </includes>
               <excludes>
                 <exclude>**/target/**</exclude>
+                <exclude>**/.idea/**</exclude>
               </excludes>
               <eclipseWtp>
                 <type>XML</type>


### PR DESCRIPTION
`urn:problem-type:cbss:input-validation:outOfRange`

Sometimes minimum and maximum constraints are dynamic, and cannot be defined in the openapi.

e.g. for pagination when requesting a page beyond the last one