### PR TITLE
Remove be.fgov.kszbcss from default scanned problem type packages

### DIFF
--- a/belgif-rest-problem-it/belgif-rest-problem-spring-it/src/main/resources/application.properties
+++ b/belgif-rest-problem-it/belgif-rest-problem-spring-it/src/main/resources/application.properties
@@ -1,2 +1,2 @@
 server.servlet.context-path=/spring
-io.github.belgif.rest.problem.spring.scan-additional-problem-packages=com.acme.custom
+io.github.belgif.rest.problem.scan-additional-problem-packages=com.acme.custom

--- a/belgif-rest-problem-spring/src/main/java/io/github/belgif/rest/problem/registry/SpringProblemTypeRegistry.java
+++ b/belgif-rest-problem-spring/src/main/java/io/github/belgif/rest/problem/registry/SpringProblemTypeRegistry.java
@@ -24,7 +24,7 @@ import io.github.belgif.rest.problem.spring.ProblemConfigurationProperties;
  * <p>
  * Uses component scanning to search the classpath for classes annotated with @ProblemType.
  * In addition to known problem base packages, additional packages can be scanned by configuring
- * io.github.belgif.rest.problem.spring.scan-additional-problem-packages.
+ * io.github.belgif.rest.problem.scan-additional-problem-packages.
  * </p>
  *
  * @see ProblemType
@@ -34,8 +34,7 @@ public class SpringProblemTypeRegistry implements ProblemTypeRegistry {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SpringProblemTypeRegistry.class);
 
-    private static final List<String> DEFAULT_SCAN_PACKAGES = Arrays.asList(
-            "io.github.belgif.rest.problem", "be.fgov.kszbcss");
+    private static final List<String> DEFAULT_SCAN_PACKAGES = Arrays.asList("io.github.belgif.rest.problem");
 
     private final NamedType[] problemTypes;
 

--- a/belgif-rest-problem-spring/src/main/java/io/github/belgif/rest/problem/spring/ProblemConfigurationProperties.java
+++ b/belgif-rest-problem-spring/src/main/java/io/github/belgif/rest/problem/spring/ProblemConfigurationProperties.java
@@ -8,7 +8,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 /**
  * Lists all supported application.properties configurations for the rest-problem-spring library.
  */
-@ConfigurationProperties(prefix = "io.github.belgif.rest.problem.spring")
+@ConfigurationProperties(prefix = "io.github.belgif.rest.problem")
 public class ProblemConfigurationProperties {
 
     private List<String> scanAdditionalProblemPackages = new ArrayList<>();

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -13,6 +13,13 @@
 
 == Release notes
 
+=== Version 0.2
+
+*belgif-rest-problem-spring:*
+
+* Remove `be.fgov.kszbcss` from default scanned problem type packages
+* Rename `io.github.belgif.rest.problem.spring.scan-additional-problem-packages` configuration property to `io.github.belgif.rest.problem.scan-additional-problem-packages`
+
 === Version 0.1
 
 Initial release under Belgif organization.
@@ -271,12 +278,12 @@ NOTE: If the service returns a problem type for which you do not have a correspo
 This module provides auto-configuration for components that handle Spring Boot integration with the belgif-rest-problem library:
 
 * *SpringProblemTypeRegistry:* ProblemTypeRegistry implementation that uses classpath scanning to detect @ProblemType annotations.
-By default, only package `io.github.belgif.rest.problem` and `be.fgov.kszbcss` are scanned for @ProblemType annotations.
+By default, only package `io.github.belgif.rest.problem` is scanned for @ProblemType annotations.
 Additional packages to scan can be configured in your application.properties:
 
 [source,properties]
 ----
-io.github.belgif.rest.problem.spring.scan-additional-problem-packages=com.acme.custom
+io.github.belgif.rest.problem.scan-additional-problem-packages=com.acme.custom
 ----
 
 * *SpringProblemModule:* a Jackson Module that registers the SpringProblemTypeRegistry.


### PR DESCRIPTION
Fixes #2. Instead of adding all core users to the default scanned problem type packages, we remove `be.fgov.kszbcss`.
Users should configure `io.github.belgif.rest.problem.scan-additional-problem-packages` in their application.properties.
They could also do this in a shared library, defining a custom `@PropertySource`.

This PR also removes the redundant "spring" from the property name
`io.github.belgif.rest.problem(.spring).scan-additional-problem-packages`.