### PR TITLE
Support Jakarta EE 9/10

### DIFF
--- a/belgif-rest-problem-it/belgif-rest-problem-jakarta-ee-it/pom.xml
+++ b/belgif-rest-problem-it/belgif-rest-problem-jakarta-ee-it/pom.xml
@@ -9,11 +9,11 @@
     <version>${revision}</version>
   </parent>
 
-  <artifactId>belgif-rest-problem-java-ee-it</artifactId>
+  <artifactId>belgif-rest-problem-jakarta-ee-it</artifactId>
   <packaging>war</packaging>
 
   <build>
-    <finalName>belgif-rest-problem-java-ee-it</finalName>
+    <finalName>belgif-rest-problem-jakarta-ee-it</finalName>
   </build>
 
   <dependencies>
@@ -21,11 +21,12 @@
       <groupId>io.github.belgif.rest.problem</groupId>
       <artifactId>belgif-rest-problem-java-ee</artifactId>
       <version>${project.version}</version>
+      <classifier>jakarta</classifier>
     </dependency>
     <dependency>
       <groupId>jakarta.platform</groupId>
       <artifactId>jakarta.jakartaee-api</artifactId>
-      <version>8.0.0</version>
+      <version>10.0.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -33,11 +34,19 @@
       <artifactId>jackson-databind</artifactId>
       <scope>provided</scope>
     </dependency>
+    <!--
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-client-microprofile</artifactId>
       <scope>provided</scope>
-      <version>3.15.6.Final</version>
+      <version>4.7.9.Final</version>
+    </dependency>
+    -->
+    <dependency>
+      <groupId>org.jboss.resteasy.microprofile</groupId>
+      <artifactId>microprofile-rest-client</artifactId>
+      <scope>provided</scope>
+      <version>2.1.5.Final</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/belgif-rest-problem-it/belgif-rest-problem-jakarta-ee-it/pom.xml
+++ b/belgif-rest-problem-it/belgif-rest-problem-jakarta-ee-it/pom.xml
@@ -34,14 +34,6 @@
       <artifactId>jackson-databind</artifactId>
       <scope>provided</scope>
     </dependency>
-    <!--
-    <dependency>
-      <groupId>org.jboss.resteasy</groupId>
-      <artifactId>resteasy-client-microprofile</artifactId>
-      <scope>provided</scope>
-      <version>4.7.9.Final</version>
-    </dependency>
-    -->
     <dependency>
       <groupId>org.jboss.resteasy.microprofile</groupId>
       <artifactId>microprofile-rest-client</artifactId>

--- a/belgif-rest-problem-it/belgif-rest-problem-jakarta-ee-it/src/main/java/com/acme/custom/CustomProblem.java
+++ b/belgif-rest-problem-it/belgif-rest-problem-jakarta-ee-it/src/main/java/com/acme/custom/CustomProblem.java
@@ -1,0 +1,36 @@
+package com.acme.custom;
+
+import java.net.URI;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import io.github.belgif.rest.problem.api.ClientProblem;
+import io.github.belgif.rest.problem.api.ProblemType;
+
+@ProblemType(CustomProblem.TYPE)
+public class CustomProblem extends ClientProblem {
+
+    public static final String TYPE = "urn:problem-type:acme:custom";
+    public static final URI TYPE_URI = URI.create(TYPE);
+    public static final String TITLE = "Custom Problem";
+    public static final int STATUS = 409;
+
+    private static final long serialVersionUID = 1L;
+
+    private String customField;
+
+    @JsonCreator
+    public CustomProblem(String customField) {
+        super(TYPE_URI, TITLE, STATUS);
+        this.customField = customField;
+    }
+
+    public void setCustomField(String customField) {
+        this.customField = customField;
+    }
+
+    public String getCustomField() {
+        return customField;
+    }
+
+}

--- a/belgif-rest-problem-it/belgif-rest-problem-jakarta-ee-it/src/main/java/io/github/belgif/rest/problem/Backend.java
+++ b/belgif-rest-problem-it/belgif-rest-problem-jakarta-ee-it/src/main/java/io/github/belgif/rest/problem/Backend.java
@@ -1,0 +1,22 @@
+package io.github.belgif.rest.problem;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
+
+@Path("/backend")
+public interface Backend {
+
+    @GET
+    @Path("/badRequest")
+    Response badRequest();
+
+    @GET
+    @Path("/custom")
+    Response custom();
+
+    @GET
+    @Path("/unmapped")
+    Response unmapped();
+
+}

--- a/belgif-rest-problem-it/belgif-rest-problem-jakarta-ee-it/src/main/java/io/github/belgif/rest/problem/BackendImpl.java
+++ b/belgif-rest-problem-it/belgif-rest-problem-jakarta-ee-it/src/main/java/io/github/belgif/rest/problem/BackendImpl.java
@@ -1,0 +1,35 @@
+package io.github.belgif.rest.problem;
+
+import java.net.URI;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.ws.rs.core.Response;
+
+import com.acme.custom.CustomProblem;
+
+import io.github.belgif.rest.problem.api.Problem;
+
+@RequestScoped
+public class BackendImpl implements Backend {
+
+    @Override
+    public Response badRequest() {
+        BadRequestProblem problem = new BadRequestProblem();
+        problem.setDetail("Bad Request from backend");
+        throw problem;
+    }
+
+    @Override
+    public Response custom() {
+        throw new CustomProblem("value from backend");
+    }
+
+    @Override
+    public Response unmapped() {
+        Problem unmapped = new Problem(URI.create("urn:problem-type:belgif:test:unmapped"), "Unmapped problem", 400) {
+        };
+        unmapped.setDetail("Unmapped problem from backend");
+        throw unmapped;
+    }
+
+}

--- a/belgif-rest-problem-it/belgif-rest-problem-jakarta-ee-it/src/main/java/io/github/belgif/rest/problem/Client.java
+++ b/belgif-rest-problem-it/belgif-rest-problem-jakarta-ee-it/src/main/java/io/github/belgif/rest/problem/Client.java
@@ -1,0 +1,7 @@
+package io.github.belgif.rest.problem;
+
+public enum Client {
+
+    MICROPROFILE, JAXRS, JAXRS_ASYNC, RESTEASY, RESTEASY_PROXY
+
+}

--- a/belgif-rest-problem-it/belgif-rest-problem-jakarta-ee-it/src/main/java/io/github/belgif/rest/problem/Frontend.java
+++ b/belgif-rest-problem-it/belgif-rest-problem-jakarta-ee-it/src/main/java/io/github/belgif/rest/problem/Frontend.java
@@ -1,0 +1,49 @@
+package io.github.belgif.rest.problem;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Response;
+
+@Path("/frontend")
+public interface Frontend {
+    @GET
+    @Path("/badRequest")
+    Response badRequest();
+
+    @GET
+    @Path("/custom")
+    Response custom();
+
+    @GET
+    @Path("/runtime")
+    Response runtime();
+
+    @GET
+    @Path("/unmapped")
+    Response unmapped();
+
+    @GET
+    @Path("/retryAfter")
+    Response retryAfter();
+
+    @GET
+    @Path("/badRequestFromBackend")
+    Response badRequestFromBackend(@QueryParam("client") Client client);
+
+    @GET
+    @Path("/customFromBackend")
+    Response customFromBackend(@QueryParam("client") Client client);
+
+    @GET
+    @Path("/unmappedFromBackend")
+    Response unmappedFromBackend(@QueryParam("client") Client client);
+
+    @GET
+    @Path("/beanValidation")
+    Response beanValidation(@QueryParam("required") @NotNull String required,
+            @QueryParam("positive") @Positive Integer positive);
+
+}

--- a/belgif-rest-problem-it/belgif-rest-problem-jakarta-ee-it/src/main/java/io/github/belgif/rest/problem/FrontendImpl.java
+++ b/belgif-rest-problem-it/belgif-rest-problem-jakarta-ee-it/src/main/java/io/github/belgif/rest/problem/FrontendImpl.java
@@ -1,0 +1,154 @@
+package io.github.belgif.rest.problem;
+
+import java.net.URI;
+import java.util.concurrent.ExecutionException;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Response;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.jboss.resteasy.client.jaxrs.internal.ResteasyClientBuilderImpl;
+
+import com.acme.custom.CustomProblem;
+
+import io.github.belgif.rest.problem.api.Problem;
+import io.github.belgif.rest.problem.jaxrs.client.ProblemSupport;
+
+@RequestScoped
+public class FrontendImpl implements Frontend {
+
+    private static final URI BASE_URI =
+            URI.create("http://" + System.getProperty("jboss.bind.address") + ":8080/rest-problem");
+
+    private final Backend microprofileClient = RestClientBuilder.newBuilder()
+            .baseUri(BASE_URI)
+            .build(Backend.class);
+
+    private jakarta.ws.rs.client.Client jaxRsClient;
+
+    private final jakarta.ws.rs.client.Client resteasyClient =
+            ProblemSupport.enable(new ResteasyClientBuilderImpl().build());
+
+    private final Backend resteasyProxyClient = ProblemSupport.enable(
+            new ResteasyClientBuilderImpl().build().target(BASE_URI).proxy(Backend.class));
+
+    @Inject
+    public void setJaxRsClient(jakarta.ws.rs.client.Client jaxRsClient) {
+        this.jaxRsClient = jaxRsClient;
+    }
+
+    @Override
+    public Response badRequest() {
+        BadRequestProblem problem = new BadRequestProblem();
+        problem.setDetail("Bad Request from frontend");
+        throw problem;
+    }
+
+    @Override
+    public Response custom() {
+        throw new CustomProblem("value from frontend");
+    }
+
+    @Override
+    public Response runtime() {
+        throw new RuntimeException("oops");
+    }
+
+    @Override
+    public Response unmapped() {
+        Problem unmapped = new Problem(URI.create("urn:problem-type:belgif:test:unmapped"), "Unmapped problem", 400) {
+        };
+        unmapped.setDetail("Unmapped problem from frontend");
+        throw unmapped;
+    }
+
+    @Override
+    public Response retryAfter() {
+        ServiceUnavailableProblem problem = new ServiceUnavailableProblem();
+        problem.setRetryAfterSec(10000L);
+        throw problem;
+    }
+
+    @Override
+    public Response badRequestFromBackend(Client client) {
+        try {
+            if (client == null || client == Client.MICROPROFILE) {
+                return microprofileClient.badRequest();
+            } else if (client == Client.JAXRS) {
+                return jaxRsClient.target(BASE_URI).path("backend/badRequest").request().get();
+            } else if (client == Client.JAXRS_ASYNC) {
+                try {
+                    jaxRsClient.target(BASE_URI).path("backend/badRequest").request().async().get().get();
+                } catch (InterruptedException | ExecutionException e) {
+                    throw new RuntimeException(e);
+                }
+            } else if (client == Client.RESTEASY) {
+                return resteasyClient.target(BASE_URI).path("backend/badRequest").request().get();
+            } else if (client == Client.RESTEASY_PROXY) {
+                return resteasyProxyClient.badRequest();
+            }
+            throw new IllegalStateException("Unsupported client " + client);
+        } catch (BadRequestProblem e) {
+            e.setDetail(e.getDetail() + " (caught successfully by frontend)");
+            throw e;
+        }
+    }
+
+    @Override
+    public Response customFromBackend(@QueryParam("client") Client client) {
+        try {
+            if (client == null || client == Client.MICROPROFILE) {
+                return microprofileClient.custom();
+            } else if (client == Client.JAXRS) {
+                return jaxRsClient.target(BASE_URI).path("backend/custom").request().buildGet().invoke();
+            } else if (client == Client.JAXRS_ASYNC) {
+                try {
+                    jaxRsClient.target(BASE_URI).path("backend/custom").request().buildGet().submit().get();
+                } catch (InterruptedException | ExecutionException e) {
+                    throw new RuntimeException(e);
+                }
+            } else if (client == Client.RESTEASY) {
+                return resteasyClient.target(BASE_URI).path("backend/custom").request().get();
+            } else if (client == Client.RESTEASY_PROXY) {
+                return resteasyProxyClient.custom();
+            }
+            throw new IllegalStateException("Unsupported client " + client);
+        } catch (CustomProblem e) {
+            e.setCustomField(e.getCustomField() + " (caught successfully by frontend)");
+            throw e;
+        }
+    }
+
+    @Override
+    public Response unmappedFromBackend(@QueryParam("client") Client client) {
+        try {
+            if (client == null || client == Client.MICROPROFILE) {
+                return microprofileClient.unmapped();
+            } else if (client == Client.JAXRS) {
+                return jaxRsClient.target(BASE_URI).path("backend/unmapped").request().get();
+            } else if (client == Client.JAXRS_ASYNC) {
+                try {
+                    jaxRsClient.target(BASE_URI).path("backend/unmapped").request().async().get().get();
+                } catch (InterruptedException | ExecutionException e) {
+                    throw new RuntimeException(e);
+                }
+            } else if (client == Client.RESTEASY) {
+                return resteasyClient.target(BASE_URI).path("backend/unmapped").request().get();
+            } else if (client == Client.RESTEASY_PROXY) {
+                return resteasyProxyClient.unmapped();
+            }
+            throw new IllegalStateException("Unsupported client " + client);
+        } catch (DefaultProblem e) {
+            e.setDetail(e.getDetail() + " (caught successfully by frontend)");
+            throw e;
+        }
+    }
+
+    @Override
+    public Response beanValidation(String required, Integer positive) {
+        return Response.ok().build();
+    }
+
+}

--- a/belgif-rest-problem-it/belgif-rest-problem-jakarta-ee-it/src/main/java/io/github/belgif/rest/problem/RESTConfig.java
+++ b/belgif-rest-problem-it/belgif-rest-problem-jakarta-ee-it/src/main/java/io/github/belgif/rest/problem/RESTConfig.java
@@ -1,0 +1,9 @@
+package io.github.belgif.rest.problem;
+
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+@ApplicationPath("/")
+public class RESTConfig extends Application {
+
+}

--- a/belgif-rest-problem-it/belgif-rest-problem-jakarta-ee-it/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/belgif-rest-problem-it/belgif-rest-problem-jakarta-ee-it/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,0 +1,3 @@
+<jboss-web>
+  <context-root>/rest-problem</context-root>
+</jboss-web>

--- a/belgif-rest-problem-it/belgif-rest-problem-jakarta-ee-it/src/test/java/io/github/belgif/rest/problem/RestProblemJakartaEeIT.java
+++ b/belgif-rest-problem-it/belgif-rest-problem-jakarta-ee-it/src/test/java/io/github/belgif/rest/problem/RestProblemJakartaEeIT.java
@@ -1,0 +1,141 @@
+package io.github.belgif.rest.problem;
+
+import static org.hamcrest.Matchers.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.MountableFile;
+
+import io.restassured.RestAssured;
+import io.restassured.specification.RequestSpecification;
+
+@Testcontainers
+class RestProblemJakartaEeIT {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RestProblemJakartaEeIT.class);
+
+    @Container
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public static final GenericContainer JBOSS_CONTAINER =
+            new GenericContainer("quay.io/wildfly/wildfly:31.0.1.Final-jdk17")
+                    .withCopyFileToContainer(
+                            MountableFile.forHostPath("target/belgif-rest-problem-jakarta-ee-it.war"),
+                            "/opt/jboss/wildfly/standalone/deployments/belgif-rest-problem-jakarta-ee-it.war")
+                    .withExposedPorts(8080)
+                    .waitingFor(Wait.forLogMessage(".*WFLYSRV0025.*", 1))
+                    .withLogConsumer(new Slf4jLogConsumer(LOGGER));
+
+    enum Client {
+        MICROPROFILE, JAXRS, JAXRS_ASYNC, RESTEASY, RESTEASY_PROXY
+    }
+
+    private RequestSpecification spec;
+
+    @BeforeEach
+    void before() {
+        spec = RestAssured.with().baseUri("http://" + JBOSS_CONTAINER.getHost())
+                .port(JBOSS_CONTAINER.getMappedPort(8080))
+                .basePath("/rest-problem/frontend");
+    }
+
+    @Test
+    void badRequest() {
+        spec.when().get("/badRequest").then().assertThat()
+                .statusCode(400)
+                .body("type", equalTo("urn:problem-type:belgif:badRequest"))
+                .body("detail", equalTo("Bad Request from frontend"));
+    }
+
+    @Test
+    void custom() {
+        spec.when().get("/custom").then().assertThat()
+                .statusCode(409)
+                .body("type", equalTo("urn:problem-type:acme:custom"))
+                .body("customField", equalTo("value from frontend"));
+    }
+
+    @Test
+    void runtime() {
+        spec.when().get("/runtime").then().assertThat()
+                .statusCode(500)
+                .body("type", equalTo("urn:problem-type:belgif:internalServerError"));
+    }
+
+    @Test
+    void unmapped() {
+        spec.when().get("/unmapped").then().assertThat()
+                .statusCode(400)
+                .body("type", equalTo("urn:problem-type:belgif:test:unmapped"))
+                .body("detail", equalTo("Unmapped problem from frontend"));
+    }
+
+    @Test
+    void retryAfter() {
+        spec.when().get("/retryAfter").then().assertThat()
+                .statusCode(503)
+                .header("Retry-After", "10000")
+                .body("type", equalTo("urn:problem-type:belgif:serviceUnavailable"));
+    }
+
+    @ParameterizedTest
+    @EnumSource
+    void badRequestFromBackend(Client client) {
+        spec.when().get("/badRequestFromBackend?client=" + client).then().assertThat()
+                .statusCode(400)
+                .body("type", equalTo("urn:problem-type:belgif:badRequest"))
+                .body("detail", equalTo("Bad Request from backend (caught successfully by frontend)"));
+    }
+
+    @ParameterizedTest
+    @EnumSource
+    void customFromBackend(Client client) {
+        spec.when().get("/customFromBackend?client=" + client).then().assertThat()
+                .statusCode(409)
+                .body("type", equalTo("urn:problem-type:acme:custom"))
+                .body("customField", equalTo("value from backend (caught successfully by frontend)"));
+    }
+
+    @ParameterizedTest
+    @EnumSource
+    void unmappedFromBackend(Client client) {
+        spec.when().get("/unmappedFromBackend?client=" + client).then().assertThat()
+                .statusCode(400)
+                .body("type", equalTo("urn:problem-type:belgif:test:unmapped"))
+                .body("detail", equalTo("Unmapped problem from backend (caught successfully by frontend)"));
+    }
+
+    @Test
+    void beanValidation() {
+        spec.when().get("/beanValidation?positive=-1").then().assertThat()
+                .statusCode(400)
+                .body("type", equalTo("urn:problem-type:belgif:badRequest"))
+                .body("issues[0].type", equalTo("urn:problem-type:belgif:input-validation:schemaViolation"))
+                .body("issues[0].title", equalTo("Input value is invalid with respect to the schema"))
+                .body("issues[0].detail", equalTo("must be greater than 0"))
+                .body("issues[0].in", equalTo("query"))
+                .body("issues[0].name", equalTo("positive"))
+                .body("issues[0].value", equalTo(-1))
+                .body("issues[1].type", equalTo("urn:problem-type:belgif:input-validation:schemaViolation"))
+                .body("issues[1].title", equalTo("Input value is invalid with respect to the schema"))
+                .body("issues[1].detail", equalTo("must not be null"))
+                .body("issues[1].in", equalTo("query"))
+                .body("issues[1].name", equalTo("required"))
+                .body("issues[1].value", nullValue());
+    }
+
+    @Test
+    void notFound() {
+        spec.when().get("/not/found").then().assertThat()
+                .statusCode(404);
+    }
+
+}

--- a/belgif-rest-problem-it/belgif-rest-problem-jakarta-ee-it/src/test/resources/logback-test.xml
+++ b/belgif-rest-problem-it/belgif-rest-problem-jakarta-ee-it/src/test/resources/logback-test.xml
@@ -1,0 +1,32 @@
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d [%thread] %.-1level %logger{36} %M - %msg%n</pattern>
+    </encoder>
+    <filter class="ch.qos.logback.classic.filter.LevelFilter">
+      <level>ERROR</level>
+      <onMatch>DENY</onMatch>
+      <onMismatch>ACCEPT</onMismatch>
+    </filter>
+    <target>System.out</target>
+  </appender>
+
+  <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d [%thread] %.-1level %logger{36} %M - %msg%n</pattern>
+    </encoder>
+    <filter class="ch.qos.logback.classic.filter.LevelFilter">
+      <level>ERROR</level>
+      <onMatch>ACCEPT</onMatch>
+      <onMismatch>DENY</onMismatch>
+    </filter>
+    <target>System.err</target>
+  </appender>
+
+  <root level="info">
+    <appender-ref ref="STDOUT" />
+    <appender-ref ref="STDERR" />
+  </root>
+
+</configuration>

--- a/belgif-rest-problem-it/pom.xml
+++ b/belgif-rest-problem-it/pom.xml
@@ -37,6 +37,7 @@
   <modules>
     <module>belgif-rest-problem-spring-it</module>
     <module>belgif-rest-problem-java-ee-it</module>
+    <module>belgif-rest-problem-jakarta-ee-it</module>
   </modules>
 
 </project>

--- a/belgif-rest-problem-java-ee/pom.xml
+++ b/belgif-rest-problem-java-ee/pom.xml
@@ -83,4 +83,33 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.eclipse.transformer</groupId>
+        <artifactId>transformer-maven-plugin</artifactId>
+        <version>0.5.0</version>
+        <executions>
+          <execution>
+            <id>create-jakarta-variant</id>
+            <phase>package</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <rules>
+            <jakartaDefaults>true</jakartaDefaults>
+          </rules>
+          <artifact>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>${project.artifactId}</artifactId>
+          </artifact>
+          <classifier>jakarta</classifier>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/belgif-rest-problem/pom.xml
+++ b/belgif-rest-problem/pom.xml
@@ -22,9 +22,9 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>jakarta.enterprise</groupId>
-      <artifactId>jakarta.enterprise.cdi-api</artifactId>
-      <version>2.0.2</version>
+      <groupId>javax.enterprise</groupId>
+      <artifactId>cdi-api</artifactId>
+      <version>2.0</version>
       <scope>provided</scope>
       <!--
         Used for @javax.enterprise.inject.Stereotype annotation on ProblemType.
@@ -33,12 +33,34 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>jakarta.ejb</groupId>
-      <artifactId>jakarta.ejb-api</artifactId>
-      <version>3.2.6</version>
+      <groupId>jakarta.enterprise</groupId>
+      <artifactId>jakarta.enterprise.cdi-api</artifactId>
+      <version>4.1.0</version>
+      <scope>provided</scope>
+      <!--
+        Used for @jakarta.enterprise.inject.Stereotype annotation on ProblemType.
+        Dependency is not required in non-CDI environments (e.g. Spring Boot).
+      -->
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>javax.ejb</groupId>
+      <artifactId>javax.ejb-api</artifactId>
+      <version>3.2.2</version>
       <scope>provided</scope>
       <!--
         Used for @javax.ejb.ApplicationException annotation on Problem.
+        Dependency is not required in non-EJB environments (e.g. Spring Boot).
+      -->
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.ejb</groupId>
+      <artifactId>jakarta.ejb-api</artifactId>
+      <version>4.0.1</version>
+      <scope>provided</scope>
+      <!--
+        Used for @jakarta.ejb.ApplicationException annotation on Problem.
         Dependency is not required in non-EJB environments (e.g. Spring Boot).
       -->
       <optional>true</optional>

--- a/belgif-rest-problem/src/main/java/io/github/belgif/rest/problem/api/Problem.java
+++ b/belgif-rest-problem/src/main/java/io/github/belgif/rest/problem/api/Problem.java
@@ -2,8 +2,6 @@ package io.github.belgif.rest.problem.api;
 
 import java.net.URI;
 
-import javax.ejb.ApplicationException;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
@@ -19,7 +17,8 @@ import io.github.belgif.rest.problem.DefaultProblem;
  *
  * Maps to Problem in belgif/problem/v1/problem-v1.yaml.
  */
-@ApplicationException
+@javax.ejb.ApplicationException
+@jakarta.ejb.ApplicationException
 // This @ApplicationException annotation is required for EJB integration (prevents wrapping in javax.ejb.EJBException).
 // Given that annotations that are not found on the classpath are ignored,
 // no EJB-api runtime dependency is required (e.g. for Spring Boot).

--- a/belgif-rest-problem/src/main/java/io/github/belgif/rest/problem/api/ProblemType.java
+++ b/belgif-rest-problem/src/main/java/io/github/belgif/rest/problem/api/ProblemType.java
@@ -5,8 +5,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import javax.enterprise.inject.Stereotype;
-
 import io.github.belgif.rest.problem.registry.ProblemTypeRegistry;
 
 /**
@@ -17,7 +15,8 @@ import io.github.belgif.rest.problem.registry.ProblemTypeRegistry;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
-@Stereotype
+@javax.enterprise.inject.Stereotype
+@jakarta.enterprise.inject.Stereotype
 // This @Stereotype annotation is required for CDI integration.
 // Given that annotations that are not found on the classpath are ignored,
 // no CDI-api runtime dependency is required (e.g. for Spring Boot).

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -15,6 +15,10 @@
 
 === Version 0.2
 
+*belgif-rest-problem-java-ee:*
+
+* Added Jakarta EE 9/10 support: use `<classifier>jakarta</classifier>`
+
 *belgif-rest-problem-spring:*
 
 * Remove `be.fgov.kszbcss` from default scanned problem type packages
@@ -31,7 +35,7 @@ Java library for working with https://www.belgif.be/specification/rest/api-guide
 The library consists of these modules:
 
 * <<belgif-rest-problem>>: library for RFC 9457 standardized Belgif problems
-* <<belgif-rest-problem-java-ee>>: Java EE integration for belgif-rest-problem
+* <<belgif-rest-problem-java-ee>>: Java EE / Jakarta EE integration for belgif-rest-problem
 * <<belgif-rest-problem-spring>>: Spring Boot integration for belgif-rest-problem
 
 [[belgif-rest-problem]]
@@ -212,7 +216,7 @@ include::../../../belgif-rest-problem-java-ee/src/test/java/adoc/CodeSamples.jav
 [[belgif-rest-problem-java-ee]]
 == belgif-rest-problem-java-ee
 
-This module provides components that handle Java EE integration with the belgif-rest-problem library:
+This module provides components that handle Java EE / Jakarta EE integration with the belgif-rest-problem library:
 
 * *CdiProblemTypeRegistry:* ProblemTypeRegistry implementation that uses CDI component scanning to detect @ProblemType annotations.
 * *CdiProblemModule:* a Jackson Module that registers the CdiProblemTypeRegistry.
@@ -249,6 +253,8 @@ public void setClient(Client client) {
 * *MicroProfile REST Client integration:*
 ** *ProblemResponseExceptionMapper:* a ResponseExceptionMapper that converts problem responses to Problem exceptions.
 ** *ProblemRestClientListener:* a RestClientListener that registers the ProblemObjectMapperContextResolver and ProblemResponseExceptionMapper.
+* *Jakarta EE 9+*: the main belgif-rest-problem-java-ee artifact targets Java EE (javax package namespace).
+A secondary artifact that targets Jakarta EE 9+ (jakarta package namespace) is available with `<classifier>jakarta</classifier>`.
 
 === Using rest-problem library for implementing REST services
 


### PR DESCRIPTION
Fixes #17:

* Use org.eclipse.transformer:transformer-maven-plugin to generate jakarta variant of belgif-rest-problem-java-ee
* Update belgif-rest-problem to use both javax and jakarta annotations
* Add belgif-rest-problem-jakarta-ee-it that uses Wildfly 31