### PR TITLE
Allow use of inputs[] and in/name/value when unmarshalling JSON

### DIFF
--- a/belgif-rest-problem-it/belgif-rest-problem-it-common/src/main/java/io/github/belgif/rest/problem/AbstractJacksonSerializationTest.java
+++ b/belgif-rest-problem-it/belgif-rest-problem-it-common/src/main/java/io/github/belgif/rest/problem/AbstractJacksonSerializationTest.java
@@ -116,6 +116,36 @@ abstract class AbstractJacksonSerializationTest {
     }
 
     @Test
+    void badRequestProblemWithInputsArrayAndInNameValue() throws JsonProcessingException {
+        String json = "{\n"
+                + "  \"type\": \"urn:problem-type:belgif:badRequest\",\n"
+                + "  \"href\": \"https://www.belgif.be/specification/rest/api-guide/problems/badRequest.html\",\n"
+                + "  \"title\": \"Bad Request\",\n"
+                + "  \"status\": 400,\n"
+                + "  \"detail\": \"my detail message\",\n"
+                + "  \"issues\": [\n"
+                + "    {\n"
+                + "      \"inputs\": [\n"
+                + "        {\n"
+                + "          \"in\": \"query\",\n"
+                + "          \"name\": \"test\",\n"
+                + "          \"value\": \"test\"\n"
+                + "        }\n"
+                + "      ],\n"
+                + "      \"in\": \"query\",\n"
+                + "      \"name\": \"test\",\n"
+                + "      \"value\": \"test\"\n"
+                + "    }\n"
+                + "  ]\n"
+                + "}";
+        Problem result = mapper.readValue(json, Problem.class);
+        assertThat(result).isInstanceOf(BadRequestProblem.class);
+        InputValidationIssue issue = ((BadRequestProblem) result).getIssues().get(0);
+        assertThat(issue.getName()).isEqualTo("test");
+        assertThat(issue.getInputs().get(0).getName()).isEqualTo("test");
+    }
+
+    @Test
     void unmappedProblem() throws JsonProcessingException {
         mapper = new ObjectMapper();
         mapper.enable(SerializationFeature.INDENT_OUTPUT);

--- a/belgif-rest-problem/src/main/java/io/github/belgif/rest/problem/api/InputValidationIssue.java
+++ b/belgif-rest-problem/src/main/java/io/github/belgif/rest/problem/api/InputValidationIssue.java
@@ -132,18 +132,6 @@ public class InputValidationIssue {
         return Collections.unmodifiableList(inputs);
     }
 
-    /**
-     * Don't fail on combined use of inputs[] and in/name/value when unmarshalling JSON.
-     *
-     * @param inputs the inputs[]
-     */
-    @JsonSetter("inputs")
-    @SuppressWarnings("unused")
-    private void setInputsFromJson(List<Input<?>> inputs) {
-        this.inputs.clear();
-        this.inputs.addAll(inputs);
-    }
-
     public void setInputs(List<Input<?>> inputs) {
         verifyNoInNameValue();
         this.inputs.clear();
@@ -181,6 +169,51 @@ public class InputValidationIssue {
     @JsonAnySetter
     public void setAdditionalProperty(String name, Object value) {
         additionalProperties.put(name, value);
+    }
+
+    /**
+     * Don't fail on combined use of inputs[] and in/name/value when unmarshalling JSON.
+     *
+     * @param inputs the inputs[]
+     */
+    @JsonSetter("inputs")
+    @SuppressWarnings("unused")
+    private void setInputsFromJson(List<Input<?>> inputs) {
+        this.inputs.clear();
+        this.inputs.addAll(inputs);
+    }
+
+    /**
+     * Don't fail on combined use of inputs[] and in/name/value when unmarshalling JSON.
+     *
+     * @param in the InEnum
+     */
+    @JsonSetter("in")
+    @SuppressWarnings("unused")
+    private void setInFromJson(InEnum in) {
+        this.in = in;
+    }
+
+    /**
+     * Don't fail on combined use of inputs[] and in/name/value when unmarshalling JSON.
+     *
+     * @param name the name
+     */
+    @JsonSetter("name")
+    @SuppressWarnings("unused")
+    private void setNameFromJson(String name) {
+        this.name = name;
+    }
+
+    /**
+     * Don't fail on combined use of inputs[] and in/name/value when unmarshalling JSON.
+     *
+     * @param value the value
+     */
+    @JsonSetter("value")
+    @SuppressWarnings("unused")
+    private void setValueFromJson(Object value) {
+        this.value = value;
     }
 
     // builder methods


### PR DESCRIPTION
While in the java API we want to prevent the instantiation of an
InputValidationIssue that combines inputs[] with in/name/value,
we do not want to fail on this when unmarshalling a JSON problem.