### PR TITLE
Handle Spring Boot 3 NoResourceFoundException

### DIFF
--- a/belgif-rest-problem-it/belgif-rest-problem-spring-boot-3-it/pom.xml
+++ b/belgif-rest-problem-it/belgif-rest-problem-spring-boot-3-it/pom.xml
@@ -17,7 +17,7 @@
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
-        <version>3.3.0</version>
+        <version>3.3.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -27,9 +27,8 @@
   <dependencies>
     <dependency>
       <groupId>io.github.belgif.rest.problem</groupId>
-      <artifactId>belgif-rest-problem-spring</artifactId>
+      <artifactId>belgif-rest-problem-spring-boot-3</artifactId>
       <version>${project.version}</version>
-      <classifier>jakarta</classifier>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/belgif-rest-problem-it/belgif-rest-problem-spring-boot-3-it/src/test/java/io/github/belgif/rest/problem/RestProblemSpringBoot3IT.java
+++ b/belgif-rest-problem-it/belgif-rest-problem-spring-boot-3-it/src/test/java/io/github/belgif/rest/problem/RestProblemSpringBoot3IT.java
@@ -1,8 +1,11 @@
 package io.github.belgif.rest.problem;
 
+import static org.hamcrest.Matchers.*;
+
 import java.util.Arrays;
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 
@@ -23,6 +26,16 @@ class RestProblemSpringBoot3IT extends AbstractRestProblemSpringBootIT {
     @Override
     protected Stream<String> getClients() {
         return Arrays.stream(Client.values()).map(Client::name);
+    }
+
+    // On Spring Boot 3.x only (for now), a proper resourceNotFound problem is returned
+    @Override
+    @Test
+    void notFound() {
+        getSpec().when().get("/not/found").then().assertThat()
+                .statusCode(404)
+                .body("type", equalTo("urn:problem-type:belgif:resourceNotFound"))
+                .body("detail", equalTo("No resource frontend/not/found found"));
     }
 
 }

--- a/belgif-rest-problem-it/belgif-rest-problem-spring-boot-3-it/src/test/java/io/github/belgif/rest/problem/RestProblemSpringBoot3IT.java
+++ b/belgif-rest-problem-it/belgif-rest-problem-spring-boot-3-it/src/test/java/io/github/belgif/rest/problem/RestProblemSpringBoot3IT.java
@@ -3,7 +3,6 @@ package io.github.belgif.rest.problem;
 import java.util.Arrays;
 import java.util.stream.Stream;
 
-import org.junit.jupiter.api.Disabled;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 
@@ -24,12 +23,6 @@ class RestProblemSpringBoot3IT extends AbstractRestProblemSpringBootIT {
     @Override
     protected Stream<String> getClients() {
         return Arrays.stream(Client.values()).map(Client::name);
-    }
-
-    @Override
-    @Disabled("Throws org.springframework.web.servlet.resource.NoResourceFoundException on latest Spring Boot 3")
-    void notFound() {
-        super.notFound();
     }
 
 }

--- a/belgif-rest-problem-it/belgif-rest-problem-spring-boot-3-it/src/test/java/io/github/belgif/rest/problem/RestProblemSpringBoot3IT.java
+++ b/belgif-rest-problem-it/belgif-rest-problem-spring-boot-3-it/src/test/java/io/github/belgif/rest/problem/RestProblemSpringBoot3IT.java
@@ -35,7 +35,7 @@ class RestProblemSpringBoot3IT extends AbstractRestProblemSpringBootIT {
         getSpec().when().get("/not/found").then().assertThat()
                 .statusCode(404)
                 .body("type", equalTo("urn:problem-type:belgif:resourceNotFound"))
-                .body("detail", equalTo("No resource frontend/not/found found"));
+                .body("detail", equalTo("No resource /frontend/not/found found"));
     }
 
 }

--- a/belgif-rest-problem-spring-boot-2/pom.xml
+++ b/belgif-rest-problem-spring-boot-2/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.github.belgif.rest.problem</groupId>
+    <artifactId>belgif-rest-problem-parent</artifactId>
+    <version>${revision}</version>
+  </parent>
+
+  <artifactId>belgif-rest-problem-spring-boot-2</artifactId>
+  <packaging>jar</packaging>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>2.7.18</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.github.belgif.rest.problem</groupId>
+      <artifactId>belgif-rest-problem-spring</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/belgif-rest-problem-spring-boot-3/pom.xml
+++ b/belgif-rest-problem-spring-boot-3/pom.xml
@@ -5,19 +5,19 @@
 
   <parent>
     <groupId>io.github.belgif.rest.problem</groupId>
-    <artifactId>belgif-rest-problem-it</artifactId>
+    <artifactId>belgif-rest-problem-parent</artifactId>
     <version>${revision}</version>
   </parent>
 
-  <artifactId>belgif-rest-problem-spring-boot-2-it</artifactId>
-  <packaging>war</packaging>
+  <artifactId>belgif-rest-problem-spring-boot-3</artifactId>
+  <packaging>jar</packaging>
 
   <dependencyManagement>
     <dependencies>
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
-        <version>2.7.18</version>
+        <version>3.3.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -27,25 +27,30 @@
   <dependencies>
     <dependency>
       <groupId>io.github.belgif.rest.problem</groupId>
-      <artifactId>belgif-rest-problem-spring-boot-2</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.github.belgif.rest.problem</groupId>
-      <artifactId>belgif-rest-problem-it-common</artifactId>
+      <artifactId>belgif-rest-problem-spring</artifactId>
+      <classifier>jakarta</classifier>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-web</artifactId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-validation</artifactId>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-web</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-webflux</artifactId>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-webmvc</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.platform</groupId>
+      <artifactId>jakarta.jakartaee-api</artifactId>
+      <version>10.0.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -53,9 +58,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.rest-assured</groupId>
-      <artifactId>rest-assured</artifactId>
-      <version>4.5.1</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/belgif-rest-problem-spring-boot-3/src/main/java/io/github/belgif/rest/problem/spring/NoResourceFoundExceptionHandler.java
+++ b/belgif-rest-problem-spring-boot-3/src/main/java/io/github/belgif/rest/problem/spring/NoResourceFoundExceptionHandler.java
@@ -1,0 +1,24 @@
+package io.github.belgif.rest.problem.spring;
+
+import org.springframework.core.annotation.Order;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
+
+import io.github.belgif.rest.problem.ResourceNotFoundProblem;
+import io.github.belgif.rest.problem.api.Problem;
+
+@RestControllerAdvice
+@Order(1)
+public class NoResourceFoundExceptionHandler {
+
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<Problem> handleNoResourceFoundException(
+            NoResourceFoundException exception) {
+        ResourceNotFoundProblem problem = new ResourceNotFoundProblem();
+        problem.setDetail(String.format("No resource %s found", exception.getResourcePath()));
+        return ProblemMediaType.INSTANCE.toResponse(problem);
+    }
+
+}

--- a/belgif-rest-problem-spring-boot-3/src/main/java/io/github/belgif/rest/problem/spring/NoResourceFoundExceptionHandler.java
+++ b/belgif-rest-problem-spring-boot-3/src/main/java/io/github/belgif/rest/problem/spring/NoResourceFoundExceptionHandler.java
@@ -17,7 +17,9 @@ public class NoResourceFoundExceptionHandler {
     public ResponseEntity<Problem> handleNoResourceFoundException(
             NoResourceFoundException exception) {
         ResourceNotFoundProblem problem = new ResourceNotFoundProblem();
-        problem.setDetail(String.format("No resource %s found", exception.getResourcePath()));
+        problem.setDetail(String.format("No resource %s found",
+                exception.getResourcePath().startsWith("/") ? exception.getResourcePath()
+                        : "/" + exception.getResourcePath()));
         return ProblemMediaType.INSTANCE.toResponse(problem);
     }
 

--- a/belgif-rest-problem-spring-boot-3/src/test/java/io/github/belgif/rest/problem/spring/NoResourceFoundExceptionHandlerTest.java
+++ b/belgif-rest-problem-spring-boot-3/src/test/java/io/github/belgif/rest/problem/spring/NoResourceFoundExceptionHandlerTest.java
@@ -24,4 +24,14 @@ class NoResourceFoundExceptionHandlerTest {
         assertThat(problem.getDetail()).isEqualTo("No resource /test found");
     }
 
+    @Test
+    void handleNoResourceFoundExceptionAddsLeadingSlash() {
+        ResponseEntity<Problem> entity = handler.handleNoResourceFoundException(
+                new NoResourceFoundException(HttpMethod.GET, "test"));
+        assertThat(entity.getStatusCode().value()).isEqualTo(404);
+        assertThat(entity.getHeaders().getContentType()).isEqualTo(ProblemMediaType.INSTANCE);
+        ResourceNotFoundProblem problem = (ResourceNotFoundProblem) entity.getBody();
+        assertThat(problem.getDetail()).isEqualTo("No resource /test found");
+    }
+
 }

--- a/belgif-rest-problem-spring-boot-3/src/test/java/io/github/belgif/rest/problem/spring/NoResourceFoundExceptionHandlerTest.java
+++ b/belgif-rest-problem-spring-boot-3/src/test/java/io/github/belgif/rest/problem/spring/NoResourceFoundExceptionHandlerTest.java
@@ -1,4 +1,4 @@
-package spring;
+package io.github.belgif.rest.problem.spring;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -9,8 +9,6 @@ import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import io.github.belgif.rest.problem.ResourceNotFoundProblem;
 import io.github.belgif.rest.problem.api.Problem;
-import io.github.belgif.rest.problem.spring.NoResourceFoundExceptionHandler;
-import io.github.belgif.rest.problem.spring.ProblemMediaType;
 
 class NoResourceFoundExceptionHandlerTest {
 

--- a/belgif-rest-problem-spring-boot-3/src/test/java/spring/NoResourceFoundExceptionHandlerTest.java
+++ b/belgif-rest-problem-spring-boot-3/src/test/java/spring/NoResourceFoundExceptionHandlerTest.java
@@ -1,0 +1,28 @@
+package spring;
+
+import io.github.belgif.rest.problem.ResourceNotFoundProblem;
+import io.github.belgif.rest.problem.api.Problem;
+import io.github.belgif.rest.problem.spring.NoResourceFoundExceptionHandler;
+import io.github.belgif.rest.problem.spring.ProblemMediaType;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
+
+import static org.assertj.core.api.Assertions.*;
+
+class NoResourceFoundExceptionHandlerTest {
+
+    private final NoResourceFoundExceptionHandler handler = new NoResourceFoundExceptionHandler();
+
+    @Test
+    void handleNoResourceFoundException() {
+        ResponseEntity<Problem> entity = handler.handleNoResourceFoundException(
+                new NoResourceFoundException(HttpMethod.GET, "/test"));
+        assertThat(entity.getStatusCode().value()).isEqualTo(404);
+        assertThat(entity.getHeaders().getContentType()).isEqualTo(ProblemMediaType.INSTANCE);
+        ResourceNotFoundProblem problem = (ResourceNotFoundProblem) entity.getBody();
+        assertThat(problem.getDetail()).isEqualTo("No resource /test found");
+    }
+
+}

--- a/belgif-rest-problem-spring-boot-3/src/test/java/spring/NoResourceFoundExceptionHandlerTest.java
+++ b/belgif-rest-problem-spring-boot-3/src/test/java/spring/NoResourceFoundExceptionHandlerTest.java
@@ -1,15 +1,16 @@
 package spring;
 
-import io.github.belgif.rest.problem.ResourceNotFoundProblem;
-import io.github.belgif.rest.problem.api.Problem;
-import io.github.belgif.rest.problem.spring.NoResourceFoundExceptionHandler;
-import io.github.belgif.rest.problem.spring.ProblemMediaType;
+import static org.assertj.core.api.Assertions.*;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
-import static org.assertj.core.api.Assertions.*;
+import io.github.belgif.rest.problem.ResourceNotFoundProblem;
+import io.github.belgif.rest.problem.api.Problem;
+import io.github.belgif.rest.problem.spring.NoResourceFoundExceptionHandler;
+import io.github.belgif.rest.problem.spring.ProblemMediaType;
 
 class NoResourceFoundExceptionHandlerTest {
 

--- a/jacoco-aggregator/pom.xml
+++ b/jacoco-aggregator/pom.xml
@@ -34,6 +34,16 @@
     </dependency>
     <dependency>
       <groupId>io.github.belgif.rest.problem</groupId>
+      <artifactId>belgif-rest-problem-spring-boot-2</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.github.belgif.rest.problem</groupId>
+      <artifactId>belgif-rest-problem-spring-boot-3</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.github.belgif.rest.problem</groupId>
       <artifactId>belgif-rest-problem-validator</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,8 @@
     <module>belgif-rest-problem-validator</module>
     <module>belgif-rest-problem-java-ee</module>
     <module>belgif-rest-problem-spring</module>
+    <module>belgif-rest-problem-spring-boot-2</module>
+    <module>belgif-rest-problem-spring-boot-3</module>
     <module>belgif-rest-problem-it</module>
   </modules>
 
@@ -219,6 +221,13 @@
               <notimestamp>true</notimestamp>
               <doctitle>belgif-rest-problem ${project.version}</doctitle>
               <excludePackageNames>*.internal</excludePackageNames>
+              <additionalDependencies>
+                <dependency>
+                  <groupId>jakarta.platform</groupId>
+                  <artifactId>jakarta.jakartaee-api</artifactId>
+                  <version>8.0.0</version>
+                </dependency>
+              </additionalDependencies>
             </configuration>
           </execution>
         </executions>
@@ -406,6 +415,8 @@
         <module>belgif-rest-problem-validator</module>
         <module>belgif-rest-problem-java-ee</module>
         <module>belgif-rest-problem-spring</module>
+        <module>belgif-rest-problem-spring-boot-2</module>
+        <module>belgif-rest-problem-spring-boot-3</module>
         <module>belgif-rest-problem-it</module>
         <module>jacoco-aggregator</module>
       </modules>

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -24,9 +24,21 @@ The library consists of these modules:
 
 * <<belgif-rest-problem>>: library for RFC 9457 standardized Belgif problems
 * <<belgif-rest-problem-java-ee>>: Java EE / Jakarta EE integration for belgif-rest-problem
-* <<belgif-rest-problem-spring>>: Spring Boot integration for belgif-rest-problem
+* <<belgif-rest-problem-spring-boot-2>>: Spring Boot 2.x integration for belgif-rest-problem
+* <<belgif-rest-problem-spring-boot-3>>: Spring Boot 3.x integration for belgif-rest-problem
 
 == Release notes
+
+=== Version 0.5
+
+*belgif-rest-problem-spring:*
+
+Split into <<belgif-rest-problem-spring-boot-2>> and <<belgif-rest-problem-spring-boot-3>>.
+To benefit from Spring Boot 2.x or 3.x specific features, replace dependencies to belgif-rest-problem-spring by the version-specific variant.
+
+*belgif-rest-problem-spring-boot-3:*
+
+* Map NoResourceFoundException to 404 `urn:problem-type:belgif:resourceNotFound`
 
 === Version 0.4
 
@@ -341,6 +353,16 @@ io.github.belgif.rest.problem.scan-additional-problem-packages=com.acme.custom
 This handles integration with the https://docs.spring.io/spring-framework/reference/web/webflux-webclient.html[Reactive WebClient].
 
 In general, these components make it possible to use standard java exception handling (throw and try-catch) for dealing with problems in Spring Boot REST APIs.
+
+[[belgif-rest-problem-spring-boot-2]]
+=== belgif-rest-problem-spring-boot-2
+
+Rather than depending on `belgif-rest-problem-spring` directly, Spring Boot 2.x users are recommended to depend on `belgif-rest-problem-spring-boot-2`, which adds some Spring Boot 2.x specific integrations.
+
+[[belgif-rest-problem-spring-boot-3]]
+=== belgif-rest-problem-spring-boot-3
+
+Rather than depending on `belgif-rest-problem-spring` directly, Spring Boot 3.x users are recommended to depend on `belgif-rest-problem-spring-boot-3`, which adds some Spring Boot 3.x specific integrations.
 
 [[code-generators]]
 == Code generators

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -357,12 +357,12 @@ In general, these components make it possible to use standard java exception han
 [[belgif-rest-problem-spring-boot-2]]
 === belgif-rest-problem-spring-boot-2
 
-Rather than depending on `belgif-rest-problem-spring` directly, Spring Boot 2.x users are recommended to depend on `belgif-rest-problem-spring-boot-2`, which adds some Spring Boot 2.x specific integrations.
+Rather than depending on <<belgif-rest-problem-spring>> directly, Spring Boot 2.x users are recommended to depend on `belgif-rest-problem-spring-boot-2`, which adds some Spring Boot 2.x specific integrations.
 
 [[belgif-rest-problem-spring-boot-3]]
 === belgif-rest-problem-spring-boot-3
 
-Rather than depending on `belgif-rest-problem-spring` directly, Spring Boot 3.x users are recommended to depend on `belgif-rest-problem-spring-boot-3`, which adds some Spring Boot 3.x specific integrations:
+Rather than depending on <<belgif-rest-problem-spring>> directly, Spring Boot 3.x users are recommended to depend on `belgif-rest-problem-spring-boot-3`, which adds some Spring Boot 3.x specific integrations:
 
 * *NoResourceFoundExceptionHandler:* an exception handler for RestControllers that converts NoResourceFoundException to HTTP 404 ResourceNotFoundProblem.
 

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -362,7 +362,9 @@ Rather than depending on `belgif-rest-problem-spring` directly, Spring Boot 2.x 
 [[belgif-rest-problem-spring-boot-3]]
 === belgif-rest-problem-spring-boot-3
 
-Rather than depending on `belgif-rest-problem-spring` directly, Spring Boot 3.x users are recommended to depend on `belgif-rest-problem-spring-boot-3`, which adds some Spring Boot 3.x specific integrations.
+Rather than depending on `belgif-rest-problem-spring` directly, Spring Boot 3.x users are recommended to depend on `belgif-rest-problem-spring-boot-3`, which adds some Spring Boot 3.x specific integrations:
+
+* *NoResourceFoundExceptionHandler:* an exception handler for RestControllers that converts NoResourceFoundException to HTTP 404 ResourceNotFoundProblem.
 
 [[code-generators]]
 == Code generators


### PR DESCRIPTION
Fixes #72.

Furthermore, this PR introduces the following modules:
* belgif-rest-problem-spring-boot-2: targets Spring Boot 2.x
* belgif-rest-problem-spring-boot-3: targets Spring Boot 3.x

belgif-rest-problem-spring contains the classes that are common to Spring Boot 2.x and 3.x.