### PR TITLE
Ensure correct Input json property order

### DIFF
--- a/belgif-rest-problem/src/main/java/io/github/belgif/rest/problem/api/Input.java
+++ b/belgif-rest-problem/src/main/java/io/github/belgif/rest/problem/api/Input.java
@@ -3,6 +3,7 @@ package io.github.belgif.rest.problem.api;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 /**
  * Input model for {@link InputValidationIssue#getInputs()}.
@@ -19,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
  *
  * @param <V> the input value type
  */
+@JsonPropertyOrder({ "in", "name", "value" })
 public class Input<V> {
 
     private InEnum in;


### PR DESCRIPTION
Default order is JDK-dependent, see https://www.tedblob.com/jackson-serialization-order/