### PR TITLE
Reproducer for issue added in IT

### DIFF
--- a/belgif-rest-problem-it/belgif-rest-problem-it-common/src/main/java/io/github/belgif/rest/problem/AbstractRestProblemIT.java
+++ b/belgif-rest-problem-it/belgif-rest-problem-it-common/src/main/java/io/github/belgif/rest/problem/AbstractRestProblemIT.java
@@ -61,6 +61,15 @@ abstract class AbstractRestProblemIT {
 
     @ParameterizedTest
     @MethodSource("getClients")
+    void happyPathFromBackend(String client) {
+        getSpec().when().queryParam("client", client)
+                .get("/happyPathFromBackend").then().assertThat()
+                .statusCode(200)
+                .body(containsString("Yes, very happy path"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("getClients")
     void badRequestFromBackend(String client) {
         getSpec().when().queryParam("client", client)
                 .get("/badRequestFromBackend").then().assertThat()
@@ -226,7 +235,7 @@ abstract class AbstractRestProblemIT {
     void constraintViolationMissingRequiredBody() {
         getSpec().when()
                 .contentType("application/json")
-                .post("/beanValidation/body").then().assertThat()
+                .post("/beanValidation/body").then().log().all().assertThat()
                 .statusCode(400)
                 .body("type", equalTo("urn:problem-type:belgif:badRequest"))
                 .body("issues[0].in", equalTo("body"))

--- a/belgif-rest-problem-it/belgif-rest-problem-it-common/src/main/java/io/github/belgif/rest/problem/AbstractRestProblemSpringBootIT.java
+++ b/belgif-rest-problem-it/belgif-rest-problem-it-common/src/main/java/io/github/belgif/rest/problem/AbstractRestProblemSpringBootIT.java
@@ -54,7 +54,7 @@ abstract class AbstractRestProblemSpringBootIT extends AbstractRestProblemIT {
                 "\"email: \"mymail.com\"" +
                 "}")
                 .contentType("application/json")
-                .post("/beanValidation/body").then().assertThat()
+                .post("/beanValidation/body").then().log().all().assertThat()
                 .statusCode(400)
                 .body("type", equalTo("urn:problem-type:belgif:badRequest"))
                 .body("issues[0].in", equalTo("body"))

--- a/belgif-rest-problem-it/belgif-rest-problem-spring-boot-3-it/src/main/java/io/github/belgif/rest/problem/BackendController.java
+++ b/belgif-rest-problem-it/belgif-rest-problem-spring-boot-3-it/src/main/java/io/github/belgif/rest/problem/BackendController.java
@@ -2,6 +2,7 @@ package io.github.belgif.rest.problem;
 
 import java.net.URI;
 
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -32,6 +33,11 @@ public class BackendController {
         };
         unmapped.setDetail("Unmapped problem from backend");
         throw unmapped;
+    }
+
+    @GetMapping("/happyPath")
+    public ResponseEntity<String> happyPath() {
+        return ResponseEntity.ok("Yes, very happy path");
     }
 
 }

--- a/belgif-rest-problem-it/belgif-rest-problem-spring-boot-3-it/src/main/java/io/github/belgif/rest/problem/FrontendController.java
+++ b/belgif-rest-problem-it/belgif-rest-problem-spring-boot-3-it/src/main/java/io/github/belgif/rest/problem/FrontendController.java
@@ -95,6 +95,26 @@ public class FrontendController implements ControllerInterface {
         throw problem;
     }
 
+    @GetMapping("/happyPathFromBackend")
+    public ResponseEntity<String> happyPathFromBackend(@RequestParam("client") Client client) {
+        String receivedString = null;
+        try {
+            if (client == Client.REST_TEMPLATE) {
+                receivedString = restTemplate.getForObject("/happyPath", String.class);
+            } else if (client == Client.WEB_CLIENT) {
+                receivedString = webClient.get().uri("/happyPath").retrieve().toEntity(String.class).block().getBody();
+            } else if (client == Client.REST_CLIENT) {
+                receivedString = restClient.get().uri("/happyPath").retrieve().toEntity(String.class).getBody();
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        if (receivedString == null) {
+            throw new RuntimeException("Client returned null");
+        }
+        return ResponseEntity.ok(receivedString);
+    }
+
     @GetMapping("/badRequestFromBackend")
     public void badRequestFromBackend(@RequestParam("client") Client client) {
         try {


### PR DESCRIPTION
Reproducer for https://github.com/belgif/rest-problem-java/issues/98
Because:

https://github.com/belgif/rest-problem-java/blob/e8f435d0ff4b11b291a12bf57507f3c85cd7b170/belgif-rest-problem-spring/src/main/java/io/github/belgif/rest/problem/spring/ProblemWebClientCustomizer.java#L23-L24

The first statement already returns true in all IT's, the statement to check statuscode is not checked in ITs.

Added reproducer for a happyPath. (does not fix the issue, build doesn't work, just a reproducer).