### PR TITLE
Upgrade to Spring Boot 3.3.4 and fix NoSuchMethodError

### DIFF
--- a/belgif-rest-problem-it/belgif-rest-problem-spring-boot-2-it/pom.xml
+++ b/belgif-rest-problem-it/belgif-rest-problem-spring-boot-2-it/pom.xml
@@ -17,7 +17,7 @@
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
-        <version>2.7.18</version>
+        <version>${version.spring.boot.2}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/belgif-rest-problem-it/belgif-rest-problem-spring-boot-3-it/pom.xml
+++ b/belgif-rest-problem-it/belgif-rest-problem-spring-boot-3-it/pom.xml
@@ -17,7 +17,7 @@
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
-        <version>3.3.1</version>
+        <version>3.3.4</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/belgif-rest-problem-it/belgif-rest-problem-spring-boot-3-it/pom.xml
+++ b/belgif-rest-problem-it/belgif-rest-problem-spring-boot-3-it/pom.xml
@@ -17,7 +17,7 @@
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
-        <version>3.3.4</version>
+        <version>${version.spring.boot.3}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/belgif-rest-problem-spring-boot-2/pom.xml
+++ b/belgif-rest-problem-spring-boot-2/pom.xml
@@ -17,7 +17,7 @@
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
-        <version>2.7.18</version>
+        <version>${version.spring.boot.2}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/belgif-rest-problem-spring-boot-3/pom.xml
+++ b/belgif-rest-problem-spring-boot-3/pom.xml
@@ -17,7 +17,7 @@
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
-        <version>3.3.1</version>
+        <version>3.3.4</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/belgif-rest-problem-spring-boot-3/pom.xml
+++ b/belgif-rest-problem-spring-boot-3/pom.xml
@@ -17,7 +17,7 @@
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
-        <version>3.3.4</version>
+        <version>${version.spring.boot.3}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/belgif-rest-problem-spring/pom.xml
+++ b/belgif-rest-problem-spring/pom.xml
@@ -17,7 +17,7 @@
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
-        <version>2.7.18</version>
+        <version>${version.spring.boot.2}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/belgif-rest-problem-spring/src/main/java/io/github/belgif/rest/problem/spring/RoutingExceptionsHandler.java
+++ b/belgif-rest-problem-spring/src/main/java/io/github/belgif/rest/problem/spring/RoutingExceptionsHandler.java
@@ -57,7 +57,7 @@ public class RoutingExceptionsHandler {
 
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
     public ResponseEntity<Void> handleHttpRequestMethodNotSupported(HttpRequestMethodNotSupportedException exception) {
-        ResponseEntity.BodyBuilder response = ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED);
+        ResponseEntity.BodyBuilder response = ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED.value());
         if (exception.getSupportedHttpMethods() != null && !exception.getSupportedHttpMethods().isEmpty()) {
             response.allow(exception.getSupportedHttpMethods().toArray(new HttpMethod[0]));
         }
@@ -66,12 +66,12 @@ public class RoutingExceptionsHandler {
 
     @ExceptionHandler(HttpMediaTypeNotAcceptableException.class)
     public ResponseEntity<Void> handleHttpMediaTypeNotAcceptable(HttpMediaTypeNotAcceptableException exception) {
-        return ResponseEntity.status(HttpStatus.NOT_ACCEPTABLE).build();
+        return ResponseEntity.status(HttpStatus.NOT_ACCEPTABLE.value()).build();
     }
 
     @ExceptionHandler(HttpMediaTypeNotSupportedException.class)
     public ResponseEntity<Void> handleHttpMediaTypeNotSupported(HttpMediaTypeNotSupportedException exception) {
-        return ResponseEntity.status(HttpStatus.UNSUPPORTED_MEDIA_TYPE).build();
+        return ResponseEntity.status(HttpStatus.UNSUPPORTED_MEDIA_TYPE.value()).build();
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <!-- Aligns with version used on JBoss EAP 7.4 -->
     <version.jackson.minimal>2.12.7</version.jackson.minimal>
+    <version.spring.boot.2>2.7.18</version.spring.boot.2>
+    <version.spring.boot.3>3.3.4</version.spring.boot.3>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
The NoSuchMethodError was introduced in #107 for Spring Boot 3:

```
 2024-09-27 12:26:54,116 [http-nio-auto-1-exec-10] W o.s.w.s.m.m.a.ExceptionHandlerExceptionResolver doResolveHandlerMethodException - Failure in @ExceptionHandler io.github.belgif.rest.problem.spring.RoutingExceptionsHandler#handleHttpMediaTypeNotSupported(HttpMediaTypeNotSupportedException)
java.lang.NoSuchMethodError: 'org.springframework.http.ResponseEntity$BodyBuilder org.springframework.http.ResponseEntity.status(org.springframework.http.HttpStatus)'
```

The reason for the NoSuchMethodError is that org.springframework.http.ResponseEntity.status(org.springframework.http.HttpStatus) changed to org.springframework.http.ResponseEntity.status(org.springframework.http.HttpStatusCode) in Spring 6 (similar to #98).

It went unnoticed because when an ExceptionHandler throws an exception, there is a fallback to https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/servlet/mvc/support/DefaultHandlerExceptionResolver.html which already maps these exceptions to the correct HTTP status code. I just accidentally noticed the warning in the logs when running a local build.