### PR TITLE
Bypass ProblemClientResponseFilter on MicroProfile REST Client

### DIFF
--- a/belgif-rest-problem-java-ee/src/main/java/io/github/belgif/rest/problem/jaxrs/client/ProblemClientResponseFilter.java
+++ b/belgif-rest-problem-java-ee/src/main/java/io/github/belgif/rest/problem/jaxrs/client/ProblemClientResponseFilter.java
@@ -42,6 +42,10 @@ public class ProblemClientResponseFilter implements ClientResponseFilter {
 
     @Override
     public void filter(ClientRequestContext request, ClientResponseContext response) throws IOException {
+        if (request.getProperty("org.eclipse.microprofile.rest.client.invokedMethod") != null) {
+            // Use io.github.belgif.rest.problem.jaxrs.client.ProblemResponseExceptionMapper on MicroProfile REST Client
+            return;
+        }
         if (ProblemMediaType.INSTANCE.isCompatible(response.getMediaType()) || (response.getStatus() >= 400
                 && MediaType.APPLICATION_JSON_TYPE.isCompatible(response.getMediaType()))) {
             Problem problem = objectMapper.readValue(response.getEntityStream(), Problem.class);

--- a/belgif-rest-problem-java-ee/src/test/java/io/github/belgif/rest/problem/jaxrs/client/ProblemClientResponseFilterTest.java
+++ b/belgif-rest-problem-java-ee/src/test/java/io/github/belgif/rest/problem/jaxrs/client/ProblemClientResponseFilterTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.*;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.lang.reflect.Method;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 
@@ -95,6 +96,15 @@ class ProblemClientResponseFilterTest {
         when(responseContext.getStatus()).thenReturn(400);
         assertThatNoException().isThrownBy(
                 () -> filter.filter(requestContext, responseContext));
+    }
+
+    @Test
+    void microProfile() {
+        when(requestContext.getProperty("org.eclipse.microprofile.rest.client.invokedMethod"))
+                .thenReturn(mock(Method.class));
+        assertThatNoException().isThrownBy(
+                () -> filter.filter(requestContext, responseContext));
+        verifyNoMoreInteractions(requestContext, responseContext);
     }
 
 }


### PR DESCRIPTION
Fixes #31.

Bypass ProblemClientResponseFilter on MicroProfile REST Client (by checking for 
[org.eclipse.microprofile.rest.client.invokedMethod](https://download.eclipse.org/microprofile/microprofile-rest-client-4.0/microprofile-rest-client-spec-4.0.html#_clientrequestfilter) property), so the MicroProfile-specific ProblemResponseExceptionMapper can be used instead.