### PR TITLE
Replace ApplicationException annotation by EJBExceptionMapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ target
 .idea
 *.iml
 belgif-rest-problem-it/belgif-rest-problem-codegen-it/src/main/resources/belgif
+belgif-rest-problem-it/belgif-rest-problem-java-ee-it/src/test/resources/standalone-openshift.xml

--- a/belgif-rest-problem-it/belgif-rest-problem-apt/pom.xml
+++ b/belgif-rest-problem-it/belgif-rest-problem-apt/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.github.belgif.rest.problem</groupId>
+    <artifactId>belgif-rest-problem-it</artifactId>
+    <version>${revision}</version>
+  </parent>
+
+  <artifactId>belgif-rest-problem-apt</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.auto.service</groupId>
+      <artifactId>auto-service</artifactId>
+      <version>1.1.1</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/belgif-rest-problem-it/belgif-rest-problem-apt/src/main/java/io/github/belgif/rest/problem/apt/DummyAnnotationProcessor.java
+++ b/belgif-rest-problem-it/belgif-rest-problem-apt/src/main/java/io/github/belgif/rest/problem/apt/DummyAnnotationProcessor.java
@@ -1,0 +1,30 @@
+package io.github.belgif.rest.problem.apt;
+
+import java.util.Set;
+
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.Processor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.TypeElement;
+
+import com.google.auto.service.AutoService;
+
+/**
+ * A dummy annotation processor implementation, to reproduce
+ * <a href="https://github.com/belgif/rest-problem-java/issues/129">#129</a>.
+ */
+@AutoService(Processor.class)
+public class DummyAnnotationProcessor extends AbstractProcessor {
+
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+        return SourceVersion.RELEASE_8;
+    }
+
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        return false;
+    }
+
+}

--- a/belgif-rest-problem-it/belgif-rest-problem-it-common/pom.xml
+++ b/belgif-rest-problem-it/belgif-rest-problem-it-common/pom.xml
@@ -18,6 +18,12 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>io.github.belgif.rest.problem</groupId>
+      <artifactId>belgif-rest-problem-apt</artifactId>
+      <version>${project.version}</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>jakarta.platform</groupId>
       <artifactId>jakarta.jakartaee-api</artifactId>
       <version>8.0.0</version>

--- a/belgif-rest-problem-it/belgif-rest-problem-it-common/src/main/java/io/github/belgif/rest/problem/AbstractRestProblemEEIT.java
+++ b/belgif-rest-problem-it/belgif-rest-problem-it-common/src/main/java/io/github/belgif/rest/problem/AbstractRestProblemEEIT.java
@@ -1,5 +1,18 @@
 package io.github.belgif.rest.problem;
 
+import static org.hamcrest.Matchers.*;
+
+import org.junit.jupiter.api.Test;
+
 abstract class AbstractRestProblemEEIT extends AbstractRestProblemIT {
+
+    @Test
+    void ejb() {
+        getSpec().when()
+                .get("/ejb").then().assertThat()
+                .statusCode(400)
+                .body("type", equalTo("urn:problem-type:belgif:badRequest"))
+                .body("detail", equalTo("problem from EJB"));
+    }
 
 }

--- a/belgif-rest-problem-it/belgif-rest-problem-jakarta-ee-it/src/main/java/io/github/belgif/rest/problem/EJBService.java
+++ b/belgif-rest-problem-it/belgif-rest-problem-jakarta-ee-it/src/main/java/io/github/belgif/rest/problem/EJBService.java
@@ -1,0 +1,14 @@
+package io.github.belgif.rest.problem;
+
+import jakarta.ejb.Stateless;
+
+@Stateless
+public class EJBService {
+
+    public void throwPoblem() {
+        BadRequestProblem problem = new BadRequestProblem();
+        problem.setDetail("problem from EJB");
+        throw problem;
+    }
+
+}

--- a/belgif-rest-problem-it/belgif-rest-problem-jakarta-ee-it/src/main/java/io/github/belgif/rest/problem/Frontend.java
+++ b/belgif-rest-problem-it/belgif-rest-problem-jakarta-ee-it/src/main/java/io/github/belgif/rest/problem/Frontend.java
@@ -36,6 +36,10 @@ public interface Frontend {
     Response unmapped();
 
     @GET
+    @Path("/ejb")
+    Response ejb();
+
+    @GET
     @Path("/retryAfter")
     Response retryAfter();
 

--- a/belgif-rest-problem-it/belgif-rest-problem-jakarta-ee-it/src/main/java/io/github/belgif/rest/problem/FrontendImpl.java
+++ b/belgif-rest-problem-it/belgif-rest-problem-jakarta-ee-it/src/main/java/io/github/belgif/rest/problem/FrontendImpl.java
@@ -3,6 +3,7 @@ package io.github.belgif.rest.problem;
 import java.net.URI;
 import java.util.concurrent.ExecutionException;
 
+import jakarta.ejb.EJB;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
 import jakarta.validation.constraints.NotNull;
@@ -43,6 +44,9 @@ public class FrontendImpl implements Frontend {
     private final Backend resteasyProxyClient = ProblemSupport.enable(
             new ResteasyClientBuilderImpl().build().target(BASE_URI).proxy(Backend.class));
 
+    @EJB
+    private EJBService ejb;
+
     @Inject
     public void setJaxRsClient(jakarta.ws.rs.client.Client jaxRsClient) {
         this.jaxRsClient = jaxRsClient;
@@ -71,6 +75,12 @@ public class FrontendImpl implements Frontend {
         };
         unmapped.setDetail("Unmapped problem from frontend");
         throw unmapped;
+    }
+
+    @Override
+    public Response ejb() {
+        ejb.throwPoblem();
+        return Response.ok().build();
     }
 
     @Override

--- a/belgif-rest-problem-it/belgif-rest-problem-java-ee-it/pom.xml
+++ b/belgif-rest-problem-it/belgif-rest-problem-java-ee-it/pom.xml
@@ -12,9 +12,115 @@
   <artifactId>belgif-rest-problem-java-ee-it</artifactId>
   <packaging>war</packaging>
 
+  <properties>
+    <docker.image>registry.redhat.io/jboss-eap-7/eap-xp4-openjdk17-openshift-rhel8:4.0-40</docker.image>
+  </properties>
+
   <build>
     <finalName>belgif-rest-problem-java-ee-it</finalName>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-clean-plugin</artifactId>
+        <configuration>
+          <filesets>
+            <fileset>
+              <directory>src/test/resources</directory>
+              <includes>
+                <include>standalone-openshift.xml</include>
+              </includes>
+            </fileset>
+          </filesets>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>pull-eap-xp4</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <configuration>
+              <executable>docker</executable>
+              <arguments>
+                <argument>pull</argument>
+                <argument>${docker.image}</argument>
+              </arguments>
+            </configuration>
+          </execution>
+          <execution>
+            <id>extract-eap-xp4-config</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <configuration>
+              <executable>docker</executable>
+              <arguments>
+                <argument>run</argument>
+                <argument>--rm</argument>
+                <argument>${docker.image}</argument>
+                <argument>cat</argument>
+                <argument>/opt/eap/standalone/configuration/standalone-openshift.xml</argument>
+              </arguments>
+              <outputFile>src/test/resources/standalone-openshift.xml</outputFile>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>enable-ejb-subsystem</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <target>
+                <replace file="src/test/resources/standalone-openshift.xml">
+                  <replacetoken>
+                    <![CDATA[
+                    <extension module="org.jboss.as.ee"/>
+                    ]]>
+                  </replacetoken>
+                  <replacevalue>
+                    <![CDATA[
+                    <extension module="org.jboss.as.ee"/>
+                    <extension module="org.jboss.as.ejb3"/>
+                    ]]>
+                  </replacevalue>
+                </replace>
+                <replace file="src/test/resources/standalone-openshift.xml">
+                  <replacetoken>
+                    <![CDATA[
+                    <subsystem xmlns="urn:jboss:domain:ee-security:1.0"/>
+                    ]]>
+                  </replacetoken>
+                  <replacevalue>
+                    <![CDATA[
+                    <subsystem xmlns="urn:jboss:domain:ee-security:1.0"/>
+                    <subsystem xmlns="urn:jboss:domain:ejb3:9.0">
+                      <thread-pools>
+                        <thread-pool name="default">
+                          <max-threads count="10"/>
+                          <keepalive-time time="60" unit="seconds"/>
+                        </thread-pool>
+                      </thread-pools>
+                    </subsystem>
+                    ]]>
+                  </replacevalue>
+                </replace>
+              </target>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>

--- a/belgif-rest-problem-it/belgif-rest-problem-java-ee-it/src/main/java/io/github/belgif/rest/problem/EJBService.java
+++ b/belgif-rest-problem-it/belgif-rest-problem-java-ee-it/src/main/java/io/github/belgif/rest/problem/EJBService.java
@@ -1,0 +1,14 @@
+package io.github.belgif.rest.problem;
+
+import javax.ejb.Stateless;
+
+@Stateless
+public class EJBService {
+
+    public void throwPoblem() {
+        BadRequestProblem problem = new BadRequestProblem();
+        problem.setDetail("problem from EJB");
+        throw problem;
+    }
+
+}

--- a/belgif-rest-problem-it/belgif-rest-problem-java-ee-it/src/main/java/io/github/belgif/rest/problem/Frontend.java
+++ b/belgif-rest-problem-it/belgif-rest-problem-java-ee-it/src/main/java/io/github/belgif/rest/problem/Frontend.java
@@ -36,6 +36,10 @@ public interface Frontend {
     Response unmapped();
 
     @GET
+    @Path("/ejb")
+    Response ejb();
+
+    @GET
     @Path("/retryAfter")
     Response retryAfter();
 

--- a/belgif-rest-problem-it/belgif-rest-problem-java-ee-it/src/main/java/io/github/belgif/rest/problem/FrontendImpl.java
+++ b/belgif-rest-problem-it/belgif-rest-problem-java-ee-it/src/main/java/io/github/belgif/rest/problem/FrontendImpl.java
@@ -3,6 +3,7 @@ package io.github.belgif.rest.problem;
 import java.net.URI;
 import java.util.concurrent.ExecutionException;
 
+import javax.ejb.EJB;
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
 import javax.validation.constraints.NotNull;
@@ -42,6 +43,9 @@ public class FrontendImpl implements Frontend {
     private final Backend resteasyProxyClient = ProblemSupport.enable(
             new ResteasyClientBuilder().build().target(BASE_URI).proxy(Backend.class));
 
+    @EJB
+    private EJBService ejb;
+
     @Inject
     public void setJaxRsClient(javax.ws.rs.client.Client jaxRsClient) {
         this.jaxRsClient = jaxRsClient;
@@ -70,6 +74,12 @@ public class FrontendImpl implements Frontend {
         };
         unmapped.setDetail("Unmapped problem from frontend");
         throw unmapped;
+    }
+
+    @Override
+    public Response ejb() {
+        ejb.throwPoblem();
+        return Response.ok().build();
     }
 
     @Override

--- a/belgif-rest-problem-it/belgif-rest-problem-java-ee-it/src/test/java/io/github/belgif/rest/problem/RestProblemJavaEeIT.java
+++ b/belgif-rest-problem-it/belgif-rest-problem-java-ee-it/src/test/java/io/github/belgif/rest/problem/RestProblemJavaEeIT.java
@@ -31,7 +31,7 @@ class RestProblemJavaEeIT extends AbstractRestProblemEEIT {
                             "-javaagent:/deployments/jacocoagent.jar=destfile=/tmp/jacoco-it.exec," +
                                     "includes=io.github.belgif.rest.problem.*")
                     .withCopyFileToContainer(
-                            MountableFile.forHostPath("src/test/resources/standalone-openshift.xml"),
+                            MountableFile.forHostPath("src/test/resources/standalone-openshift.xml", 777),
                             "/opt/eap/standalone/configuration/standalone-openshift.xml")
                     .withCopyFileToContainer(
                             MountableFile.forHostPath("target/dependency/jacocoagent.jar"),

--- a/belgif-rest-problem-it/belgif-rest-problem-java-ee-it/src/test/java/io/github/belgif/rest/problem/RestProblemJavaEeIT.java
+++ b/belgif-rest-problem-it/belgif-rest-problem-java-ee-it/src/test/java/io/github/belgif/rest/problem/RestProblemJavaEeIT.java
@@ -26,10 +26,13 @@ class RestProblemJavaEeIT extends AbstractRestProblemEEIT {
     @Container
     @SuppressWarnings({ "rawtypes", "unchecked" })
     public static final GenericContainer JBOSS_CONTAINER =
-            new GenericContainer("registry.redhat.io/jboss-eap-7/eap-xp4-openjdk17-openshift-rhel8:4.0-29")
+            new GenericContainer("registry.redhat.io/jboss-eap-7/eap-xp4-openjdk17-openshift-rhel8:4.0-40")
                     .withEnv("JAVA_OPTS_APPEND",
                             "-javaagent:/deployments/jacocoagent.jar=destfile=/tmp/jacoco-it.exec," +
                                     "includes=io.github.belgif.rest.problem.*")
+                    .withCopyFileToContainer(
+                            MountableFile.forHostPath("src/test/resources/standalone-openshift.xml"),
+                            "/opt/eap/standalone/configuration/standalone-openshift.xml")
                     .withCopyFileToContainer(
                             MountableFile.forHostPath("target/dependency/jacocoagent.jar"),
                             "/deployments/jacocoagent.jar")

--- a/belgif-rest-problem-it/belgif-rest-problem-java-ee-it/src/test/java/io/github/belgif/rest/problem/RestProblemJavaEeIT.java
+++ b/belgif-rest-problem-it/belgif-rest-problem-java-ee-it/src/test/java/io/github/belgif/rest/problem/RestProblemJavaEeIT.java
@@ -31,7 +31,7 @@ class RestProblemJavaEeIT extends AbstractRestProblemEEIT {
                             "-javaagent:/deployments/jacocoagent.jar=destfile=/tmp/jacoco-it.exec," +
                                     "includes=io.github.belgif.rest.problem.*")
                     .withCopyFileToContainer(
-                            MountableFile.forHostPath("src/test/resources/standalone-openshift.xml", 777),
+                            MountableFile.forHostPath("src/test/resources/standalone-openshift.xml", 0777),
                             "/opt/eap/standalone/configuration/standalone-openshift.xml")
                     .withCopyFileToContainer(
                             MountableFile.forHostPath("target/dependency/jacocoagent.jar"),

--- a/belgif-rest-problem-it/pom.xml
+++ b/belgif-rest-problem-it/pom.xml
@@ -35,11 +35,12 @@
   </build>
 
   <modules>
+    <module>belgif-rest-problem-apt</module>
+    <module>belgif-rest-problem-it-common</module>
     <module>belgif-rest-problem-spring-boot-2-it</module>
     <module>belgif-rest-problem-spring-boot-3-it</module>
     <module>belgif-rest-problem-java-ee-it</module>
     <module>belgif-rest-problem-jakarta-ee-it</module>
-    <module>belgif-rest-problem-it-common</module>
     <module>belgif-rest-problem-jackson-minimal-it</module>
     <module>belgif-rest-problem-jackson-latest-it</module>
     <module>belgif-rest-problem-codegen-it</module>

--- a/belgif-rest-problem-java-ee/src/main/java/io/github/belgif/rest/problem/jaxrs/EJBExceptionMapper.java
+++ b/belgif-rest-problem-java-ee/src/main/java/io/github/belgif/rest/problem/jaxrs/EJBExceptionMapper.java
@@ -1,0 +1,40 @@
+package io.github.belgif.rest.problem.jaxrs;
+
+import javax.ejb.EJBException;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import io.github.belgif.rest.problem.api.Problem;
+
+/**
+ * ExceptionMapper for unhandled EJBExceptions.
+ *
+ * <p>
+ * Routes to {@link ProblemExceptionMapper} when the EJBException is caused by a Problem exception.
+ * This is a workaround to avoid having to annotate Problem with @ApplicationException.
+ * Otherwise, routes to {@link DefaultExceptionMapper}.
+ * </p>
+ *
+ * @see ExceptionMapper
+ * @see EJBException
+ * @see ProblemExceptionMapper
+ * @see DefaultExceptionMapper
+ */
+@Provider
+public class EJBExceptionMapper implements ExceptionMapper<EJBException> {
+
+    private static final ProblemExceptionMapper PROBLEM_MAPPER = new ProblemExceptionMapper();
+
+    private static final DefaultExceptionMapper DEFAULT_MAPPER = new DefaultExceptionMapper();
+
+    @Override
+    public Response toResponse(EJBException exception) {
+        if (exception.getCause() instanceof Problem) {
+            return PROBLEM_MAPPER.toResponse((Problem) exception.getCause());
+        } else {
+            return DEFAULT_MAPPER.toResponse(exception);
+        }
+    }
+
+}

--- a/belgif-rest-problem-java-ee/src/test/java/io/github/belgif/rest/problem/jaxrs/EJBExceptionMapperTest.java
+++ b/belgif-rest-problem-java-ee/src/test/java/io/github/belgif/rest/problem/jaxrs/EJBExceptionMapperTest.java
@@ -1,0 +1,31 @@
+package io.github.belgif.rest.problem.jaxrs;
+
+import static org.assertj.core.api.Assertions.*;
+
+import javax.ejb.EJBException;
+import javax.ws.rs.core.Response;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.belgif.rest.problem.BadRequestProblem;
+import io.github.belgif.rest.problem.InternalServerErrorProblem;
+
+class EJBExceptionMapperTest {
+
+    private final EJBExceptionMapper mapper = new EJBExceptionMapper();
+
+    @Test
+    void problemCause() {
+        Response response = mapper.toResponse(new EJBException(new BadRequestProblem()));
+        assertThat(response.getStatus()).isEqualTo(400);
+        assertThat(response.getEntity()).isInstanceOf(BadRequestProblem.class);
+    }
+
+    @Test
+    void otherCause() {
+        Response response = mapper.toResponse(new EJBException(new RuntimeException("other")));
+        assertThat(response.getStatus()).isEqualTo(500);
+        assertThat(response.getEntity()).isInstanceOf(InternalServerErrorProblem.class);
+    }
+
+}

--- a/belgif-rest-problem/pom.xml
+++ b/belgif-rest-problem/pom.xml
@@ -45,28 +45,6 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>javax.ejb</groupId>
-      <artifactId>javax.ejb-api</artifactId>
-      <version>3.2.2</version>
-      <scope>provided</scope>
-      <!--
-        Used for @javax.ejb.ApplicationException annotation on Problem.
-        Dependency is not required in non-EJB environments (e.g. Spring Boot).
-      -->
-      <optional>true</optional>
-    </dependency>
-    <dependency>
-      <groupId>jakarta.ejb</groupId>
-      <artifactId>jakarta.ejb-api</artifactId>
-      <version>4.0.1</version>
-      <scope>provided</scope>
-      <!--
-        Used for @jakarta.ejb.ApplicationException annotation on Problem.
-        Dependency is not required in non-EJB environments (e.g. Spring Boot).
-      -->
-      <optional>true</optional>
-    </dependency>
-    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>

--- a/belgif-rest-problem/src/main/java/io/github/belgif/rest/problem/api/Problem.java
+++ b/belgif-rest-problem/src/main/java/io/github/belgif/rest/problem/api/Problem.java
@@ -22,11 +22,6 @@ import io.github.belgif.rest.problem.DefaultProblem;
  *
  * Maps to Problem in belgif/problem/v1/problem-v1.yaml.
  */
-@javax.ejb.ApplicationException
-@jakarta.ejb.ApplicationException
-// This @ApplicationException annotation is required for EJB integration (prevents wrapping in javax.ejb.EJBException).
-// Given that annotations that are not found on the classpath are ignored,
-// no EJB-api runtime dependency is required (e.g. for Spring Boot).
 @JsonTypeInfo(
         // this configures the existing "type" property as discriminator for polymorphic deserialization
         use = Id.NAME, include = As.EXISTING_PROPERTY, property = "type", visible = true,

--- a/pom.xml
+++ b/pom.xml
@@ -184,6 +184,16 @@
             <classifier>jakarta</classifier>
           </configuration>
         </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>exec-maven-plugin</artifactId>
+          <version>3.5.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-antrun-plugin</artifactId>
+          <version>3.1.0</version>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
@@ -307,6 +317,7 @@
               <excludes>
                 <exclude>**/target/**</exclude>
                 <exclude>**/.idea/**</exclude>
+                <exclude>**/standalone-openshift.xml</exclude>
               </excludes>
               <eclipseWtp>
                 <type>XML</type>
@@ -416,7 +427,8 @@
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.projectName>rest-problem-java</sonar.projectName>
         <sonar.projectKey>belgif_rest-problem-java</sonar.projectKey>
-        <sonar.coverage.jacoco.xmlReportPaths>${maven.multiModuleProjectDirectory}/jacoco-aggregator/target/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
+        <sonar.coverage.jacoco.xmlReportPaths>${maven.multiModuleProjectDirectory}/jacoco-aggregator/target/jacoco.xml
+        </sonar.coverage.jacoco.xmlReportPaths>
         <sonar.coverage.exclusions>**/belgif-rest-problem-it/**</sonar.coverage.exclusions>
         <sonar.cpd.exclusions>**/belgif-rest-problem-it/**,**/src/test/java/**</sonar.cpd.exclusions>
       </properties>

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -473,6 +473,9 @@ Its priority of "Priorities.USER + 200" allows it to be overridden if needed by 
 * *ProblemExceptionMapper:* a JAX-RS ExceptionMapper that converts Problem exceptions to a proper application/problem+json response.
 * *WebApplicationExceptionMapper:* a JAX-RS ExceptionMapper that handles WebApplicationExceptions thrown by the JAX-RS runtime itself, to prevent them from being handled by the DefaultExceptionMapper.
 * *DefaultExceptionMapper:* a JAX-RS ExceptionMapper that converts any other uncaught exception to an HTTP 500 InternalServerErrorProblem.
+* *EJBExceptionMapper:* a JAX-RS ExceptionMapper that handles EJBExceptions.
+Routes to ProblemExceptionMapper when the EJBException is caused by a Problem exception.
+Otherwise, routes to DefaultExceptionMapper.
 * *JaxRsParameterNameProvider*: a bean validation ParameterNameProvider that retrieves parameter names from JAX-RS annotations
 
 * *JAX-RS Client integration:*

--- a/src/main/asciidoc/release-notes.adoc
+++ b/src/main/asciidoc/release-notes.adoc
@@ -12,6 +12,16 @@
 
 // tag::recent-versions[]
 
+== Version 0.10
+
+*belgif-rest-problem:*
+
+* Remove @ApplicationException annotation on Problem, because it could potentially cause compilation errors when used in combination with annotation processors
+
+*belgif-rest-problem-java-ee:*
+
+* Add EJBExceptionMapper that unwraps Problem cause, to address the removed @ApplicationException annotation
+
 == Version 0.9
 
 *belgif-rest-problem-bom:*


### PR DESCRIPTION
Fixes #129.

* Add dummy annotation processor implementation to reproduce the compilation problem
* Add EJB integration test
* Remove `@ApplicationException` annotation on Problem class
* Add EJBExceptionMapper to unwrap Problem cause, to address the
removed `@ApplicationException` annotation

Note that the ejb-jar.xml approach suggested in #129 did not work.
The ejb-jar.xml needs to be located in the user application, it does not
get picked up from dependency jars.