### PR TITLE
Update 0.10 release notes

### DIFF
--- a/src/main/asciidoc/release-notes.adoc
+++ b/src/main/asciidoc/release-notes.adoc
@@ -19,7 +19,15 @@
 * Remove @ApplicationException annotation on Problem, because it could potentially cause compilation errors when used in combination with annotation processors
 * Disallow creation of InputValidationIssue with inputs[] of size 1
 +
-WARNING: *Potentially breaking:* removed `InputValidationIssue.setInputs(List<Input<?>> inputs)` and `InputValidationIssue.input(Input<?> input)`
+[WARNING]
+====
+*Potentially breaking:*
+
+* removed `InputValidationIssue.setInputs(List<Input<?>> inputs)`
+* removed `InputValidationIssue.setInputs(Input<?>... inputs)`
+* removed `InputValidationIssue.input(Input<?> input)`
+
+====
 
 *belgif-rest-problem-java-ee:*
 

--- a/src/main/asciidoc/release-notes.adoc
+++ b/src/main/asciidoc/release-notes.adoc
@@ -19,7 +19,7 @@
 * Remove @ApplicationException annotation on Problem, because it could potentially cause compilation errors when used in combination with annotation processors
 * Disallow creation of InputValidationIssue with inputs[] of size 1
 +
-WARNING: *Potentially breaking:* removed InputValidationIssue.setInputs()
+WARNING: *Potentially breaking:* removed `InputValidationIssue.setInputs(List<Input<?>> inputs)` and `InputValidationIssue.input(Input<?> input)`
 
 *belgif-rest-problem-java-ee:*
 


### PR DESCRIPTION
`InputValidationIssue.input(Input<?> input)` method was removed and could be potentially breaking.