### PR TITLE
Don't include null issue (input) value when serializing

### DIFF
--- a/belgif-rest-problem-it/belgif-rest-problem-it-common/src/main/java/io/github/belgif/rest/problem/AbstractJacksonSerializationTest.java
+++ b/belgif-rest-problem-it/belgif-rest-problem-it-common/src/main/java/io/github/belgif/rest/problem/AbstractJacksonSerializationTest.java
@@ -224,6 +224,24 @@ abstract class AbstractJacksonSerializationTest {
         assertSerializationRoundtrip(problem);
     }
 
+    @Test
+    void issueWithNullValue() throws JsonProcessingException {
+        BadRequestProblem problem = new BadRequestProblem(
+                new InputValidationIssue(InEnum.BODY, "id", null));
+        String json = mapper.writeValueAsString(problem);
+        assertThat(json).doesNotContain("null");
+        assertSerializationRoundtrip(problem);
+    }
+
+    @Test
+    void issueWithNullInputValue() throws JsonProcessingException {
+        BadRequestProblem problem = new BadRequestProblem(new InputValidationIssue()
+                .inputs(Input.body("a", null), Input.body("b", null)));
+        String json = mapper.writeValueAsString(problem);
+        assertThat(json).doesNotContain("null");
+        assertSerializationRoundtrip(problem);
+    }
+
     void assertSerializationRoundtrip(Problem problem) throws JsonProcessingException {
         String json = mapper.writeValueAsString(problem);
         print(json);

--- a/belgif-rest-problem/src/main/java/io/github/belgif/rest/problem/api/Input.java
+++ b/belgif-rest-problem/src/main/java/io/github/belgif/rest/problem/api/Input.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  *
  * @param <V> the input value type
  */
+@JsonInclude(value = JsonInclude.Include.NON_EMPTY)
 @JsonPropertyOrder({ "in", "name", "value" })
 public class Input<V> {
 
@@ -52,7 +53,6 @@ public class Input<V> {
         this.name = name;
     }
 
-    @JsonInclude(value = JsonInclude.Include.ALWAYS, content = JsonInclude.Include.ALWAYS)
     public V getValue() {
         return value;
     }

--- a/belgif-rest-problem/src/main/java/io/github/belgif/rest/problem/api/InputValidationIssue.java
+++ b/belgif-rest-problem/src/main/java/io/github/belgif/rest/problem/api/InputValidationIssue.java
@@ -32,7 +32,7 @@ import com.fasterxml.jackson.annotation.JsonSetter;
  *
  * @see InputValidationProblem
  */
-@JsonInclude(value = Include.NON_DEFAULT)
+@JsonInclude(value = Include.NON_EMPTY)
 @JsonPropertyOrder(value = { "type", "href", "title", "detail", "in", "name", "value", "inputs" })
 public class InputValidationIssue {
 
@@ -123,7 +123,6 @@ public class InputValidationIssue {
         this.name = name;
     }
 
-    @JsonInclude(value = Include.NON_NULL, content = Include.ALWAYS)
     public Object getValue() {
         return value;
     }

--- a/src/main/asciidoc/release-notes.adoc
+++ b/src/main/asciidoc/release-notes.adoc
@@ -12,6 +12,12 @@
 
 // tag::recent-versions[]
 
+== Version 0.12
+
+*belgif-rest-problem:*
+
+* Don't include null (issue) input values when serializing
+
 == Version 0.11
 
 *belgif-rest-problem:*


### PR DESCRIPTION
Currently, null input value is included when serializing.
This was done to explicitly denote an absent input.
But that does not seem important enough to deviate from the Belgif
guideline for omitting absent properties rather than returning null.