### PR TITLE
Improve WWW-Authenticate headers

### DIFF
--- a/belgif-rest-problem/src/main/java/io/github/belgif/rest/problem/ExpiredAccessTokenProblem.java
+++ b/belgif-rest-problem/src/main/java/io/github/belgif/rest/problem/ExpiredAccessTokenProblem.java
@@ -3,6 +3,7 @@ package io.github.belgif.rest.problem;
 import java.net.URI;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Objects;
 
 import io.github.belgif.rest.problem.api.ClientProblem;
 import io.github.belgif.rest.problem.api.HttpResponseHeaders;
@@ -50,15 +51,48 @@ public class ExpiredAccessTokenProblem extends ClientProblem implements HttpResp
 
     private static final long serialVersionUID = 1L;
 
+    private String realm;
+
     public ExpiredAccessTokenProblem() {
         super(TYPE_URI, HREF, TITLE, STATUS);
         setDetail(DETAIL);
     }
 
+    public ExpiredAccessTokenProblem(String realm) {
+        this();
+        this.realm = realm;
+    }
+
+    public ExpiredAccessTokenProblem realm(String realm) {
+        this.realm = realm;
+        return this;
+    }
+
     @Override
     public Map<String, Object> getHttpResponseHeaders() {
         return Collections.singletonMap(WWW_AUTHENTICATE,
-                "Bearer error=\"invalid_token\", error_description=\"The access token expired\"");
+                "Bearer " + (realm != null ? "realm=\"" + realm + "\", " : "")
+                        + "error=\"invalid_token\", error_description=\"The access token expired\"");
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        ExpiredAccessTokenProblem that = (ExpiredAccessTokenProblem) o;
+        return Objects.equals(realm, that.realm);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), realm);
     }
 
 }

--- a/belgif-rest-problem/src/main/java/io/github/belgif/rest/problem/InvalidAccessTokenProblem.java
+++ b/belgif-rest-problem/src/main/java/io/github/belgif/rest/problem/InvalidAccessTokenProblem.java
@@ -53,6 +53,8 @@ public class InvalidAccessTokenProblem extends ClientProblem implements HttpResp
 
     private final String reason;
 
+    private String realm;
+
     public InvalidAccessTokenProblem() {
         this(DETAIL, "The access token is invalid");
     }
@@ -67,10 +69,16 @@ public class InvalidAccessTokenProblem extends ClientProblem implements HttpResp
         this.reason = reason;
     }
 
+    public InvalidAccessTokenProblem realm(String realm) {
+        this.realm = realm;
+        return this;
+    }
+
     @Override
     public Map<String, Object> getHttpResponseHeaders() {
         return Collections.singletonMap(WWW_AUTHENTICATE,
-                String.format("Bearer error=\"invalid_token\", error_description=\"%s\"", reason));
+                String.format("Bearer " + (realm != null ? "realm=\"" + realm + "\", " : "")
+                        + "error=\"invalid_token\", error_description=\"%s\"", reason));
     }
 
     @Override
@@ -85,12 +93,12 @@ public class InvalidAccessTokenProblem extends ClientProblem implements HttpResp
             return false;
         }
         InvalidAccessTokenProblem that = (InvalidAccessTokenProblem) o;
-        return Objects.equals(reason, that.reason);
+        return Objects.equals(reason, that.reason) && Objects.equals(realm, that.realm);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), reason);
+        return Objects.hash(super.hashCode(), reason, realm);
     }
 
 }

--- a/belgif-rest-problem/src/main/java/io/github/belgif/rest/problem/MissingScopeProblem.java
+++ b/belgif-rest-problem/src/main/java/io/github/belgif/rest/problem/MissingScopeProblem.java
@@ -53,6 +53,8 @@ public class MissingScopeProblem extends ClientProblem implements HttpResponseHe
 
     private final List<String> requiredScopes = new ArrayList<>();
 
+    private String realm;
+
     public MissingScopeProblem() {
         super(TYPE_URI, HREF, TITLE, STATUS);
     }
@@ -60,6 +62,11 @@ public class MissingScopeProblem extends ClientProblem implements HttpResponseHe
     public MissingScopeProblem(String... requiredScopes) {
         super(TYPE_URI, HREF, TITLE, STATUS);
         setRequiredScopes(requiredScopes);
+    }
+
+    public MissingScopeProblem realm(String realm) {
+        this.realm = realm;
+        return this;
     }
 
     public List<String> getRequiredScopes() {
@@ -93,17 +100,21 @@ public class MissingScopeProblem extends ClientProblem implements HttpResponseHe
             return false;
         }
         MissingScopeProblem that = (MissingScopeProblem) o;
-        return Objects.equals(requiredScopes, that.requiredScopes);
+        return Objects.equals(requiredScopes, that.requiredScopes) && Objects.equals(realm, that.realm);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), requiredScopes);
+        return Objects.hash(super.hashCode(), requiredScopes, realm);
     }
 
     @Override
     public Map<String, Object> getHttpResponseHeaders() {
-        return Collections.singletonMap(WWW_AUTHENTICATE, "Bearer error=\"insufficient_scope\"");
+        return Collections.singletonMap(WWW_AUTHENTICATE,
+                "Bearer " + (realm != null ? "realm=\"" + realm + "\", " : "")
+                        + "error=\"insufficient_scope\", error_description=\"Missing scope to perform request\""
+                        + (!requiredScopes.isEmpty()
+                                ? ", scope=\"" + String.join(" ", requiredScopes) + "\"" : ""));
     }
 
 }

--- a/belgif-rest-problem/src/main/java/io/github/belgif/rest/problem/NoAccessTokenProblem.java
+++ b/belgif-rest-problem/src/main/java/io/github/belgif/rest/problem/NoAccessTokenProblem.java
@@ -3,6 +3,7 @@ package io.github.belgif.rest.problem;
 import java.net.URI;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Objects;
 
 import io.github.belgif.rest.problem.api.ClientProblem;
 import io.github.belgif.rest.problem.api.HttpResponseHeaders;
@@ -50,14 +51,47 @@ public class NoAccessTokenProblem extends ClientProblem implements HttpResponseH
 
     private static final long serialVersionUID = 1L;
 
+    private String realm;
+
     public NoAccessTokenProblem() {
         super(TYPE_URI, HREF, TITLE, STATUS);
         setDetail(DETAIL);
     }
 
+    public NoAccessTokenProblem(String realm) {
+        this();
+        this.realm = realm;
+    }
+
+    public NoAccessTokenProblem realm(String realm) {
+        this.realm = realm;
+        return this;
+    }
+
     @Override
     public Map<String, Object> getHttpResponseHeaders() {
-        return Collections.singletonMap(WWW_AUTHENTICATE, "Bearer");
+        return Collections.singletonMap(WWW_AUTHENTICATE,
+                "Bearer" + (realm != null ? " realm=\"" + realm + "\"" : ""));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        NoAccessTokenProblem that = (NoAccessTokenProblem) o;
+        return Objects.equals(realm, that.realm);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), realm);
     }
 
 }

--- a/belgif-rest-problem/src/test/java/io/github/belgif/rest/problem/ExpiredAccessTokenProblemTest.java
+++ b/belgif-rest-problem/src/test/java/io/github/belgif/rest/problem/ExpiredAccessTokenProblemTest.java
@@ -24,6 +24,20 @@ class ExpiredAccessTokenProblemTest {
     }
 
     @Test
+    void constructWithRealm() {
+        ExpiredAccessTokenProblem problem = new ExpiredAccessTokenProblem("test");
+        assertThat(problem.getHttpResponseHeaders()).containsEntry(HttpResponseHeaders.WWW_AUTHENTICATE,
+                "Bearer realm=\"test\", error=\"invalid_token\", error_description=\"The access token expired\"");
+    }
+
+    @Test
+    void realm() {
+        ExpiredAccessTokenProblem problem = new ExpiredAccessTokenProblem().realm("test");
+        assertThat(problem.getHttpResponseHeaders()).containsEntry(HttpResponseHeaders.WWW_AUTHENTICATE,
+                "Bearer realm=\"test\", error=\"invalid_token\", error_description=\"The access token expired\"");
+    }
+
+    @Test
     void problemTypeAnnotation() {
         assertThat(ExpiredAccessTokenProblem.class).hasAnnotation(ProblemType.class);
         assertThat(ExpiredAccessTokenProblem.class.getAnnotation(ProblemType.class).value())

--- a/belgif-rest-problem/src/test/java/io/github/belgif/rest/problem/ExpiredAccessTokenProblemTest.java
+++ b/belgif-rest-problem/src/test/java/io/github/belgif/rest/problem/ExpiredAccessTokenProblemTest.java
@@ -44,4 +44,23 @@ class ExpiredAccessTokenProblemTest {
                 .isEqualTo("urn:problem-type:belgif:expiredAccessToken");
     }
 
+    @Test
+    void equalsAndHashCode() {
+        ExpiredAccessTokenProblem problem = new ExpiredAccessTokenProblem("A");
+        ExpiredAccessTokenProblem equal = new ExpiredAccessTokenProblem("A");
+        ExpiredAccessTokenProblem other = new ExpiredAccessTokenProblem("B");
+        ExpiredAccessTokenProblem otherBis = new ExpiredAccessTokenProblem();
+        otherBis.setDetail("other");
+
+        assertThat(problem).isEqualTo(problem);
+        assertThat(problem).hasSameHashCodeAs(problem);
+        assertThat(problem).isEqualTo(equal);
+        assertThat(problem).hasSameHashCodeAs(equal);
+        assertThat(problem).hasToString(equal.toString());
+        assertThat(problem).isNotEqualTo(other);
+        assertThat(problem).isNotEqualTo(otherBis);
+        assertThat(problem).doesNotHaveSameHashCodeAs(other);
+        assertThat(problem).isNotEqualTo("other type");
+    }
+
 }

--- a/belgif-rest-problem/src/test/java/io/github/belgif/rest/problem/InvalidAccessTokenProblemTest.java
+++ b/belgif-rest-problem/src/test/java/io/github/belgif/rest/problem/InvalidAccessTokenProblemTest.java
@@ -24,6 +24,13 @@ class InvalidAccessTokenProblemTest {
     }
 
     @Test
+    void realm() {
+        InvalidAccessTokenProblem problem = new InvalidAccessTokenProblem().realm("test");
+        assertThat(problem.getHttpResponseHeaders()).containsEntry(HttpResponseHeaders.WWW_AUTHENTICATE,
+                "Bearer realm=\"test\", error=\"invalid_token\", error_description=\"The access token is invalid\"");
+    }
+
+    @Test
     void customReason() {
         InvalidAccessTokenProblem problem = new InvalidAccessTokenProblem("Custom reason");
         assertThat(problem.getType()).hasToString("urn:problem-type:belgif:invalidAccessToken");

--- a/belgif-rest-problem/src/test/java/io/github/belgif/rest/problem/MissingScopeProblemTest.java
+++ b/belgif-rest-problem/src/test/java/io/github/belgif/rest/problem/MissingScopeProblemTest.java
@@ -20,13 +20,24 @@ class MissingScopeProblemTest {
         assertThat(problem.getTitle()).isEqualTo("Missing Scope");
         assertThat(problem.getStatus()).isEqualTo(403);
         assertThat(problem.getHttpResponseHeaders()).containsEntry(HttpResponseHeaders.WWW_AUTHENTICATE,
-                "Bearer error=\"insufficient_scope\"");
+                "Bearer error=\"insufficient_scope\", error_description=\"Missing scope to perform request\"");
+    }
+
+    @Test
+    void realm() {
+        MissingScopeProblem problem = new MissingScopeProblem().realm("test");
+        assertThat(problem.getHttpResponseHeaders()).containsEntry(HttpResponseHeaders.WWW_AUTHENTICATE,
+                "Bearer realm=\"test\", error=\"insufficient_scope\", "
+                        + "error_description=\"Missing scope to perform request\"");
     }
 
     @Test
     void constructWithRequiredScopes() {
         MissingScopeProblem problem = new MissingScopeProblem("required-scope");
         assertThat(problem.getRequiredScopes()).isUnmodifiable().containsExactly("required-scope");
+        assertThat(problem.getHttpResponseHeaders()).containsEntry(HttpResponseHeaders.WWW_AUTHENTICATE,
+                "Bearer error=\"insufficient_scope\", error_description=\"Missing scope to perform request\"" +
+                        ", scope=\"required-scope\"");
     }
 
     @Test

--- a/belgif-rest-problem/src/test/java/io/github/belgif/rest/problem/NoAccessTokenProblemTest.java
+++ b/belgif-rest-problem/src/test/java/io/github/belgif/rest/problem/NoAccessTokenProblemTest.java
@@ -23,6 +23,20 @@ class NoAccessTokenProblemTest {
     }
 
     @Test
+    void constructWithRealm() {
+        NoAccessTokenProblem problem = new NoAccessTokenProblem("test");
+        assertThat(problem.getHttpResponseHeaders()).containsEntry(HttpResponseHeaders.WWW_AUTHENTICATE,
+                "Bearer realm=\"test\"");
+    }
+
+    @Test
+    void realm() {
+        NoAccessTokenProblem problem = new NoAccessTokenProblem().realm("test");
+        assertThat(problem.getHttpResponseHeaders()).containsEntry(HttpResponseHeaders.WWW_AUTHENTICATE,
+                "Bearer realm=\"test\"");
+    }
+
+    @Test
     void problemTypeAnnotation() {
         assertThat(NoAccessTokenProblem.class).hasAnnotation(ProblemType.class);
         assertThat(NoAccessTokenProblem.class.getAnnotation(ProblemType.class).value())

--- a/belgif-rest-problem/src/test/java/io/github/belgif/rest/problem/NoAccessTokenProblemTest.java
+++ b/belgif-rest-problem/src/test/java/io/github/belgif/rest/problem/NoAccessTokenProblemTest.java
@@ -43,4 +43,23 @@ class NoAccessTokenProblemTest {
                 .isEqualTo("urn:problem-type:belgif:noAccessToken");
     }
 
+    @Test
+    void equalsAndHashCode() {
+        NoAccessTokenProblem problem = new NoAccessTokenProblem("A");
+        NoAccessTokenProblem equal = new NoAccessTokenProblem("A");
+        NoAccessTokenProblem other = new NoAccessTokenProblem("B");
+        NoAccessTokenProblem otherBis = new NoAccessTokenProblem();
+        otherBis.setDetail("other");
+
+        assertThat(problem).isEqualTo(problem);
+        assertThat(problem).hasSameHashCodeAs(problem);
+        assertThat(problem).isEqualTo(equal);
+        assertThat(problem).hasSameHashCodeAs(equal);
+        assertThat(problem).hasToString(equal.toString());
+        assertThat(problem).isNotEqualTo(other);
+        assertThat(problem).isNotEqualTo(otherBis);
+        assertThat(problem).doesNotHaveSameHashCodeAs(other);
+        assertThat(problem).isNotEqualTo("other type");
+    }
+
 }

--- a/src/main/asciidoc/release-notes.adoc
+++ b/src/main/asciidoc/release-notes.adoc
@@ -21,7 +21,7 @@
 by standardized `urn:problem-type:belgif:input-validation:referencedResourceNotFound`
 * Improve WWW-Authenticate header for token-related problem types:
 ** Support setting the "realm" attribute
-** Add "error_description" for missing_scope
+** Add "error_description" and "scope" attributes for missing_scope
 
 == Version 0.11
 

--- a/src/main/asciidoc/release-notes.adoc
+++ b/src/main/asciidoc/release-notes.adoc
@@ -19,6 +19,9 @@
 * Don't include null (issue) input values when serializing
 * Replace `urn:problem-type:cbss:input-validation:referencedResourceNotFound`
 by standardized `urn:problem-type:belgif:input-validation:referencedResourceNotFound`
+* Improve WWW-Authenticate header for token-related problem types:
+** Support setting the "realm" attribute
+** Add "error_description" for missing_scope
 
 == Version 0.11
 


### PR DESCRIPTION
See https://github.com/belgif/rest-guide/pull/215 for more context.

* Support setting the "realm" attribute
* Add "error_description" and "scope" attributes for missing_scope