### PR TITLE
Fix belgif-rest-problem-java-ee inconsistent i18n package

### DIFF
--- a/belgif-rest-problem-java-ee/src/main/java/io/github/belgif/rest/problem/ee/jaxrs/i18n/I18NAcceptLanguageFilter.java
+++ b/belgif-rest-problem-java-ee/src/main/java/io/github/belgif/rest/problem/ee/jaxrs/i18n/I18NAcceptLanguageFilter.java
@@ -1,4 +1,4 @@
-package io.github.belgif.rest.problem.jaxrs.i18n;
+package io.github.belgif.rest.problem.ee.jaxrs.i18n;
 
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;

--- a/belgif-rest-problem-java-ee/src/main/java/io/github/belgif/rest/problem/ee/jaxrs/i18n/I18NConfigurator.java
+++ b/belgif-rest-problem-java-ee/src/main/java/io/github/belgif/rest/problem/ee/jaxrs/i18n/I18NConfigurator.java
@@ -1,4 +1,4 @@
-package io.github.belgif.rest.problem.jaxrs.i18n;
+package io.github.belgif.rest.problem.ee.jaxrs.i18n;
 
 import static io.github.belgif.rest.problem.i18n.I18N.*;
 

--- a/belgif-rest-problem-java-ee/src/main/java/io/github/belgif/rest/problem/ee/jaxrs/i18n/ThreadLocalLocaleResolver.java
+++ b/belgif-rest-problem-java-ee/src/main/java/io/github/belgif/rest/problem/ee/jaxrs/i18n/ThreadLocalLocaleResolver.java
@@ -1,4 +1,4 @@
-package io.github.belgif.rest.problem.jaxrs.i18n;
+package io.github.belgif.rest.problem.ee.jaxrs.i18n;
 
 import java.util.Locale;
 

--- a/belgif-rest-problem-java-ee/src/main/resources/META-INF/services/io.github.belgif.rest.problem.i18n.LocaleResolver
+++ b/belgif-rest-problem-java-ee/src/main/resources/META-INF/services/io.github.belgif.rest.problem.i18n.LocaleResolver
@@ -1,1 +1,1 @@
-io.github.belgif.rest.problem.jaxrs.i18n.ThreadLocalLocaleResolver
+io.github.belgif.rest.problem.ee.jaxrs.i18n.ThreadLocalLocaleResolver

--- a/belgif-rest-problem-java-ee/src/test/java/io/github/belgif/rest/problem/ee/jaxrs/i18n/I18NAcceptLanguageFilterTest.java
+++ b/belgif-rest-problem-java-ee/src/test/java/io/github/belgif/rest/problem/ee/jaxrs/i18n/I18NAcceptLanguageFilterTest.java
@@ -1,4 +1,4 @@
-package io.github.belgif.rest.problem.jaxrs.i18n;
+package io.github.belgif.rest.problem.ee.jaxrs.i18n;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;

--- a/belgif-rest-problem-java-ee/src/test/java/io/github/belgif/rest/problem/ee/jaxrs/i18n/I18NConfiguratorTest.java
+++ b/belgif-rest-problem-java-ee/src/test/java/io/github/belgif/rest/problem/ee/jaxrs/i18n/I18NConfiguratorTest.java
@@ -1,4 +1,4 @@
-package io.github.belgif.rest.problem.jaxrs.i18n;
+package io.github.belgif.rest.problem.ee.jaxrs.i18n;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;

--- a/belgif-rest-problem-java-ee/src/test/java/io/github/belgif/rest/problem/ee/jaxrs/i18n/ThreadLocalLocaleResolverTest.java
+++ b/belgif-rest-problem-java-ee/src/test/java/io/github/belgif/rest/problem/ee/jaxrs/i18n/ThreadLocalLocaleResolverTest.java
@@ -1,4 +1,4 @@
-package io.github.belgif.rest.problem.jaxrs.i18n;
+package io.github.belgif.rest.problem.ee.jaxrs.i18n;
 
 import static org.assertj.core.api.Assertions.*;
 


### PR DESCRIPTION
Followup of #156. The i18n classes were added later on, and are in the wrong package.