### PR TITLE
Improve referencedResourceNotFound support for collection values

### DIFF
--- a/belgif-rest-problem/src/main/java/io/github/belgif/rest/problem/api/InputValidationIssues.java
+++ b/belgif-rest-problem/src/main/java/io/github/belgif/rest/problem/api/InputValidationIssues.java
@@ -119,7 +119,7 @@ public class InputValidationIssues {
 
     /**
      * Creates a proper {@link InputValidationIssue} for an {@link #ISSUE_TYPE_REFERENCED_RESOURCE_NOT_FOUND} where the
-     * resource reference originated from a collection parameter. For the sake of clarity the name (e.g. scope) is
+     * resource reference originated from a collection parameter. For the sake of clarity the name (e.g. scopes) is
      * enriched with its position in the collection.
      *
      * @param in The location in the request of the parameter that contained the reference
@@ -133,9 +133,7 @@ public class InputValidationIssues {
      */
     public static <T> InputValidationIssue referencedResourceNotFound(InEnum in, String name, T value, List<T> source) {
         String nameWithIndex = name + "[" + source.indexOf(value) + "]";
-        return new InputValidationIssue(ISSUE_TYPE_REFERENCED_RESOURCE_NOT_FOUND, "Referenced resource not found")
-                .localizedDetail("referencedResourceNotFound", nameWithIndex, value)
-                .in(in, nameWithIndex, value);
+        return referencedResourceNotFound(in, nameWithIndex, value);
     }
 
     public static InputValidationIssue rejectedInput(InEnum in, String name, Object value) {

--- a/belgif-rest-problem/src/main/java/io/github/belgif/rest/problem/api/InputValidationIssues.java
+++ b/belgif-rest-problem/src/main/java/io/github/belgif/rest/problem/api/InputValidationIssues.java
@@ -121,7 +121,7 @@ public class InputValidationIssues {
      * Creates a proper {@link InputValidationIssue} for an {@link #ISSUE_TYPE_REFERENCED_RESOURCE_NOT_FOUND} where the
      * resource reference originated from a collection parameter. For the sake of clarity the name (e.g. scope) is
      * enriched with its position in the collection.
-     * 
+     *
      * @param in The location in the request of the parameter that contained the reference
      * @param name The name of the parameter that contained the reference, will be enriched with its position in the
      *        source {@link List}

--- a/belgif-rest-problem/src/main/java/io/github/belgif/rest/problem/api/InputValidationIssues.java
+++ b/belgif-rest-problem/src/main/java/io/github/belgif/rest/problem/api/InputValidationIssues.java
@@ -112,6 +112,27 @@ public class InputValidationIssues {
                 .in(in, name, value);
     }
 
+    /**
+     * Creates a proper {@link InputValidationIssue} for an {@link #ISSUE_TYPE_REFERENCED_RESOURCE_NOT_FOUND} where the
+     * resource reference originated from a collection parameter. For the sake of clarity the name (e.g. scope) is
+     * enriched with its position in the collection.
+     * 
+     * @param in The location in the request of the parameter that contained the reference
+     * @param name The name of the parameter that contained the reference, will be enriched with its position in the
+     *        source {@link List}
+     * @param value The reference value
+     * @param source The source {@link List} that contained the reference
+     * @return A properly initialized {@link InputValidationIssue} for an
+     *         {@link #ISSUE_TYPE_REFERENCED_RESOURCE_NOT_FOUND}
+     * @param <T> The type of the reference
+     */
+    public static <T> InputValidationIssue referencedResourceNotFound(InEnum in, String name, T value, List<T> source) {
+        String nameWithIndex = name + "[" + source.indexOf(value) + "]";
+        return new InputValidationIssue(ISSUE_TYPE_REFERENCED_RESOURCE_NOT_FOUND, "Referenced resource not found")
+                .localizedDetail("referencedResourceNotFound", nameWithIndex, value)
+                .in(in, nameWithIndex, value);
+    }
+
     public static InputValidationIssue rejectedInput(InEnum in, String name, Object value) {
         return invalidInputExt(ISSUE_TYPE_REJECTED_INPUT, "Input is not allowed in this context")
                 .localizedDetail("rejectedInput", name)

--- a/belgif-rest-problem/src/main/java/io/github/belgif/rest/problem/api/InputValidationIssues.java
+++ b/belgif-rest-problem/src/main/java/io/github/belgif/rest/problem/api/InputValidationIssues.java
@@ -107,9 +107,14 @@ public class InputValidationIssues {
     }
 
     public static InputValidationIssue referencedResourceNotFound(InEnum in, String name, Object value) {
+        return referencedResourceNotFound(in, name, name, value);
+    }
+
+    public static InputValidationIssue referencedResourceNotFound(InEnum in, String parameterName, String resourceName,
+            Object value) {
         return new InputValidationIssue(ISSUE_TYPE_REFERENCED_RESOURCE_NOT_FOUND, "Referenced resource not found")
-                .localizedDetail("referencedResourceNotFound", name, value)
-                .in(in, name, value);
+                .localizedDetail("referencedResourceNotFound", resourceName, value)
+                .in(in, parameterName, value);
     }
 
     /**

--- a/belgif-rest-problem/src/test/java/io/github/belgif/rest/problem/api/InputValidationIssuesTest.java
+++ b/belgif-rest-problem/src/test/java/io/github/belgif/rest/problem/api/InputValidationIssuesTest.java
@@ -187,6 +187,20 @@ class InputValidationIssuesTest {
         assertThat(issue).extracting("href", "inputs", "additionalProperties").allMatch(this::isEmpty);
     }
 
+    @Test
+    void referencedResourceFromCollectionParameterNotFound() {
+        InputValidationIssue issue =
+                InputValidationIssues.referencedResourceNotFound(InEnum.BODY, "test", "value",
+                        Arrays.asList("other-value", "value", "another-value"));
+        assertThat(issue.getType()).hasToString("urn:problem-type:belgif:input-validation:referencedResourceNotFound");
+        assertThat(issue.getTitle()).isEqualTo("Referenced resource not found");
+        assertThat(issue.getIn()).isEqualTo(InEnum.BODY);
+        assertThat(issue.getName()).isEqualTo("test[1]");
+        assertThat(issue.getValue()).isEqualTo("value");
+        assertThat(issue.getDetail()).isEqualTo("Referenced resource test[1] = 'value' does not exist");
+        assertThat(issue).extracting("href", "inputs", "additionalProperties").allMatch(this::isEmpty);
+    }
+
     @ParameterizedTest
     @MethodSource("toggleExtIssueTypes")
     void rejectedInput(boolean extIssueTypes) {

--- a/belgif-rest-problem/src/test/java/io/github/belgif/rest/problem/api/InputValidationIssuesTest.java
+++ b/belgif-rest-problem/src/test/java/io/github/belgif/rest/problem/api/InputValidationIssuesTest.java
@@ -188,16 +188,29 @@ class InputValidationIssuesTest {
     }
 
     @Test
-    void referencedResourceFromCollectionParameterNotFound() {
+    void referencedResourceNotFoundDifferentResourceAndParameterName() {
         InputValidationIssue issue =
-                InputValidationIssues.referencedResourceNotFound(InEnum.BODY, "test", "value",
-                        Arrays.asList("other-value", "value", "another-value"));
+                InputValidationIssues.referencedResourceNotFound(InEnum.BODY, "partners", "organization", "0123456789");
         assertThat(issue.getType()).hasToString("urn:problem-type:belgif:input-validation:referencedResourceNotFound");
         assertThat(issue.getTitle()).isEqualTo("Referenced resource not found");
         assertThat(issue.getIn()).isEqualTo(InEnum.BODY);
-        assertThat(issue.getName()).isEqualTo("test[1]");
-        assertThat(issue.getValue()).isEqualTo("value");
-        assertThat(issue.getDetail()).isEqualTo("Referenced resource test[1] = 'value' does not exist");
+        assertThat(issue.getName()).isEqualTo("partners");
+        assertThat(issue.getValue()).isEqualTo("0123456789");
+        assertThat(issue.getDetail()).isEqualTo("Referenced resource organization = '0123456789' does not exist");
+        assertThat(issue).extracting("href", "inputs", "additionalProperties").allMatch(this::isEmpty);
+    }
+
+    @Test
+    void referencedResourceFromCollectionParameterNotFound() {
+        InputValidationIssue issue =
+                InputValidationIssues.referencedResourceNotFound(InEnum.BODY, "partners", 123,
+                        Arrays.asList(1, 123, 3));
+        assertThat(issue.getType()).hasToString("urn:problem-type:belgif:input-validation:referencedResourceNotFound");
+        assertThat(issue.getTitle()).isEqualTo("Referenced resource not found");
+        assertThat(issue.getIn()).isEqualTo(InEnum.BODY);
+        assertThat(issue.getName()).isEqualTo("partners[1]");
+        assertThat(issue.getValue()).isEqualTo(123);
+        assertThat(issue.getDetail()).isEqualTo("Referenced resource partners[1] = '123' does not exist");
         assertThat(issue).extracting("href", "inputs", "additionalProperties").allMatch(this::isEmpty);
     }
 


### PR DESCRIPTION
Adds the reference position to the parameter name of a referencedResourceNotFound issue when the parameter was a collection