### PR TITLE
Improve EE / Quarkus support

### DIFF
--- a/belgif-rest-problem-it/belgif-rest-problem-quarkus-it/pom.xml
+++ b/belgif-rest-problem-it/belgif-rest-problem-quarkus-it/pom.xml
@@ -67,7 +67,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/belgif-rest-problem-it/belgif-rest-problem-quarkus-it/src/main/resources/application.properties
+++ b/belgif-rest-problem-it/belgif-rest-problem-quarkus-it/src/main/resources/application.properties
@@ -7,9 +7,4 @@ quarkus.container-image.build=true
 quarkus.container-image.group=belgif
 quarkus.native.container-build=true
 quarkus.native.container-runtime=docker
-#Fatal error: org.graalvm.compiler.debug.GraalError: org.graalvm.compiler.debug.GraalError:
-#com.oracle.svm.hosted.substitute.DeletedElementException: Unsupported method java.lang.Object.wait0(long) is reachable
-#To diagnose the issue, you can add the option --report-unsupported-elements-at-runtime.
-#The unsupported element is then reported at run time when it is accessed the first time.
-quarkus.native.report-errors-at-runtime=true
 quarkus.native.resources.includes=com/acme/custom/Messages*.properties

--- a/belgif-rest-problem-java-ee-client/src/main/java/io/github/belgif/rest/problem/ee/jaxrs/client/ClientProblemObjectMapperContextResolver.java
+++ b/belgif-rest-problem-java-ee-client/src/main/java/io/github/belgif/rest/problem/ee/jaxrs/client/ClientProblemObjectMapperContextResolver.java
@@ -1,0 +1,29 @@
+package io.github.belgif.rest.problem.ee.jaxrs.client;
+
+import javax.annotation.Priority;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.ext.ContextResolver;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.github.belgif.rest.problem.ee.jaxrs.ProblemObjectMapper;
+
+/**
+ * Separate client-side ObjectMapper ContextResolver.
+ *
+ * <p>
+ * Workaround for a weird bug in JBoss EAP XP MicroProfile REST client:
+ * java.lang.ArrayIndexOutOfBoundsException: Index 0 out of bounds for length 0
+ * at org.jboss.resteasy.spi.ResteasyProviderFactory.addContextResolver(ResteasyProviderFactory.java:1518)
+ * If the ContextResolver class is not annotated with @Provider it works as expected.
+ * </p>
+ */
+@Priority(Priorities.USER + 200)
+public class ClientProblemObjectMapperContextResolver implements ContextResolver<ObjectMapper> {
+
+    @Override
+    public ObjectMapper getContext(Class<?> type) {
+        return ProblemObjectMapper.INSTANCE;
+    }
+
+}

--- a/belgif-rest-problem-java-ee-client/src/main/java/io/github/belgif/rest/problem/ee/jaxrs/client/ProblemClientResponseFilter.java
+++ b/belgif-rest-problem-java-ee-client/src/main/java/io/github/belgif/rest/problem/ee/jaxrs/client/ProblemClientResponseFilter.java
@@ -1,12 +1,16 @@
 package io.github.belgif.rest.problem.ee.jaxrs.client;
 
 import java.io.IOException;
-import java.util.Objects;
 
+import javax.annotation.PostConstruct;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
 import javax.ws.rs.client.ClientRequestContext;
 import javax.ws.rs.client.ClientResponseContext;
 import javax.ws.rs.client.ClientResponseFilter;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.ext.Providers;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -15,6 +19,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.github.belgif.rest.problem.DefaultProblem;
 import io.github.belgif.rest.problem.api.Problem;
+import io.github.belgif.rest.problem.ee.jaxrs.JaxRsUtil;
 import io.github.belgif.rest.problem.ee.jaxrs.ProblemMediaType;
 import io.github.belgif.rest.problem.ee.jaxrs.ProblemObjectMapper;
 
@@ -28,18 +33,26 @@ public class ProblemClientResponseFilter implements ClientResponseFilter {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ProblemClientResponseFilter.class);
 
-    private final ObjectMapper objectMapper;
+    @Inject
+    private Instance<ObjectMapper> cdiObjectMapper;
 
-    public ProblemClientResponseFilter() {
-        this(ProblemObjectMapper.INSTANCE);
-    }
+    @Context
+    private Providers providers;
 
-    public ProblemClientResponseFilter(ObjectMapper objectMapper) {
-        this.objectMapper = Objects.requireNonNull(objectMapper, "ObjectMapper should not be null");
+    private volatile ObjectMapper objectMapper;
+
+    @PostConstruct
+    public void init() {
+        if (this.objectMapper == null) {
+            this.objectMapper = JaxRsUtil.locateObjectMapper(
+                    providers, cdiObjectMapper, Problem.class,
+                    MediaType.APPLICATION_JSON_TYPE, () -> ProblemObjectMapper.INSTANCE);
+        }
     }
 
     @Override
     public void filter(ClientRequestContext request, ClientResponseContext response) throws IOException {
+        init(); // because not all JAX-RS implementations honor the @PostConstruct
         if (request.getProperty("org.eclipse.microprofile.rest.client.invokedMethod") != null) {
             // Use io.github.belgif.rest.problem.jaxrs.client.ProblemResponseExceptionMapper on MicroProfile REST Client
             return;

--- a/belgif-rest-problem-java-ee-client/src/main/java/io/github/belgif/rest/problem/ee/jaxrs/client/ProblemClientResponseFilter.java
+++ b/belgif-rest-problem-java-ee-client/src/main/java/io/github/belgif/rest/problem/ee/jaxrs/client/ProblemClientResponseFilter.java
@@ -52,11 +52,11 @@ public class ProblemClientResponseFilter implements ClientResponseFilter {
 
     @Override
     public void filter(ClientRequestContext request, ClientResponseContext response) throws IOException {
-        init(); // because not all JAX-RS implementations honor the @PostConstruct
         if (request.getProperty("org.eclipse.microprofile.rest.client.invokedMethod") != null) {
             // Use io.github.belgif.rest.problem.jaxrs.client.ProblemResponseExceptionMapper on MicroProfile REST Client
             return;
         }
+        init(); // because not all JAX-RS implementations honor the @PostConstruct
         if (ProblemMediaType.INSTANCE.isCompatible(response.getMediaType()) || (response.getStatus() >= 400
                 && MediaType.APPLICATION_JSON_TYPE.isCompatible(response.getMediaType()))) {
             Problem problem = objectMapper.readValue(response.getEntityStream(), Problem.class);

--- a/belgif-rest-problem-java-ee-client/src/main/java/io/github/belgif/rest/problem/ee/jaxrs/client/ProblemRestClientListener.java
+++ b/belgif-rest-problem-java-ee-client/src/main/java/io/github/belgif/rest/problem/ee/jaxrs/client/ProblemRestClientListener.java
@@ -1,15 +1,9 @@
 package io.github.belgif.rest.problem.ee.jaxrs.client;
 
-import javax.annotation.Priority;
-import javax.ws.rs.Priorities;
-import javax.ws.rs.ext.ContextResolver;
-
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.eclipse.microprofile.rest.client.spi.RestClientListener;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import io.github.belgif.rest.problem.ee.jaxrs.ProblemObjectMapper;
+import io.github.belgif.rest.problem.ee.jaxrs.JaxRsUtil;
 import io.github.belgif.rest.problem.ee.util.Platform;
 
 /**
@@ -25,21 +19,9 @@ public class ProblemRestClientListener implements RestClientListener {
 
     @Override
     public void onNewClient(Class<?> serviceInterface, RestClientBuilder builder) {
-        builder.register(ProblemResponseExceptionMapper.class);
+        JaxRsUtil.register(builder, ProblemResponseExceptionMapper.class);
         if (!Platform.isQuarkus()) {
-            builder.register(ClientProblemObjectMapperContextResolver.class);
-        }
-    }
-
-    // Workaround for a weird bug in JBoss EAP XP MicroProfile REST client:
-    // java.lang.ArrayIndexOutOfBoundsException: Index 0 out of bounds for length 0
-    // at org.jboss.resteasy.spi.ResteasyProviderFactory.addContextResolver(ResteasyProviderFactory.java:1518)
-    // If the ContextResolver class is not annotated with @Provider it works as expected.
-    @Priority(Priorities.USER + 200)
-    public static class ClientProblemObjectMapperContextResolver implements ContextResolver<ObjectMapper> {
-        @Override
-        public ObjectMapper getContext(Class<?> type) {
-            return ProblemObjectMapper.INSTANCE;
+            JaxRsUtil.register(builder, ClientProblemObjectMapperContextResolver.class);
         }
     }
 

--- a/belgif-rest-problem-java-ee-client/src/main/java/io/github/belgif/rest/problem/ee/jaxrs/client/ProblemRestClientListener.java
+++ b/belgif-rest-problem-java-ee-client/src/main/java/io/github/belgif/rest/problem/ee/jaxrs/client/ProblemRestClientListener.java
@@ -2,11 +2,15 @@ package io.github.belgif.rest.problem.ee.jaxrs.client;
 
 import javax.annotation.Priority;
 import javax.ws.rs.Priorities;
+import javax.ws.rs.ext.ContextResolver;
 
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.eclipse.microprofile.rest.client.spi.RestClientListener;
 
-import io.github.belgif.rest.problem.ee.jaxrs.ProblemObjectMapperContextResolver;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.github.belgif.rest.problem.ee.jaxrs.ProblemObjectMapper;
+import io.github.belgif.rest.problem.ee.util.Platform;
 
 /**
  * Listener that enables problem support for MicroProfile REST Clients.
@@ -21,8 +25,10 @@ public class ProblemRestClientListener implements RestClientListener {
 
     @Override
     public void onNewClient(Class<?> serviceInterface, RestClientBuilder builder) {
-        builder.register(ClientProblemObjectMapperContextResolver.class);
         builder.register(ProblemResponseExceptionMapper.class);
+        if (!Platform.isQuarkus()) {
+            builder.register(ClientProblemObjectMapperContextResolver.class);
+        }
     }
 
     // Workaround for a weird bug in JBoss EAP XP MicroProfile REST client:
@@ -30,7 +36,11 @@ public class ProblemRestClientListener implements RestClientListener {
     // at org.jboss.resteasy.spi.ResteasyProviderFactory.addContextResolver(ResteasyProviderFactory.java:1518)
     // If the ContextResolver class is not annotated with @Provider it works as expected.
     @Priority(Priorities.USER + 200)
-    public static class ClientProblemObjectMapperContextResolver extends ProblemObjectMapperContextResolver {
+    public static class ClientProblemObjectMapperContextResolver implements ContextResolver<ObjectMapper> {
+        @Override
+        public ObjectMapper getContext(Class<?> type) {
+            return ProblemObjectMapper.INSTANCE;
+        }
     }
 
 }

--- a/belgif-rest-problem-java-ee-client/src/main/java/io/github/belgif/rest/problem/ee/jaxrs/client/ProblemSupport.java
+++ b/belgif-rest-problem-java-ee-client/src/main/java/io/github/belgif/rest/problem/ee/jaxrs/client/ProblemSupport.java
@@ -15,6 +15,9 @@ import javax.ws.rs.client.Client;
 import javax.ws.rs.client.Invocation;
 import javax.ws.rs.client.WebTarget;
 
+import io.github.belgif.rest.problem.ee.jaxrs.JaxRsUtil;
+import io.github.belgif.rest.problem.ee.util.Platform;
+
 /**
  * Utility class for enabling problem support on JAX-RS Clients.
  */
@@ -35,8 +38,9 @@ public class ProblemSupport {
      * @return the problem-enabled JAX-RS Client
      */
     public static Client enable(Client client) {
-        if (!client.getConfiguration().isRegistered(ProblemClientResponseFilter.class)) {
-            client.register(ProblemClientResponseFilter.class);
+        JaxRsUtil.register(client, ProblemClientResponseFilter.class);
+        if (!Platform.isQuarkus()) {
+            JaxRsUtil.register(client, ClientProblemObjectMapperContextResolver.class);
         }
         return createProxy(Client.class, new ClientInvocationHandler(client));
     }

--- a/belgif-rest-problem-java-ee-client/src/main/java/io/github/belgif/rest/problem/ee/resteasy/client/ResteasyProblemSupport.java
+++ b/belgif-rest-problem-java-ee-client/src/main/java/io/github/belgif/rest/problem/ee/resteasy/client/ResteasyProblemSupport.java
@@ -7,9 +7,12 @@ import java.lang.reflect.Proxy;
 
 import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
 
+import io.github.belgif.rest.problem.ee.jaxrs.JaxRsUtil;
+import io.github.belgif.rest.problem.ee.jaxrs.client.ClientProblemObjectMapperContextResolver;
 import io.github.belgif.rest.problem.ee.jaxrs.client.ProblemClientResponseFilter;
 import io.github.belgif.rest.problem.ee.jaxrs.client.ProblemSupport;
 import io.github.belgif.rest.problem.ee.jaxrs.client.ProblemWrapper;
+import io.github.belgif.rest.problem.ee.util.Platform;
 
 /**
  * Utility class for enabling problem support on RESTEasy Clients.
@@ -30,8 +33,9 @@ public class ResteasyProblemSupport {
      */
     @SuppressWarnings("unchecked")
     public static <T> T proxy(ResteasyWebTarget target, Class<T> proxyInterface) {
-        if (!target.getConfiguration().isRegistered(ProblemClientResponseFilter.class)) {
-            target.register(ProblemClientResponseFilter.class);
+        JaxRsUtil.register(target, ProblemClientResponseFilter.class);
+        if (!Platform.isQuarkus()) {
+            JaxRsUtil.register(target, ClientProblemObjectMapperContextResolver.class);
         }
         T client = target.proxy(proxyInterface);
         return (T) Proxy.newProxyInstance(ProblemSupport.class.getClassLoader(),

--- a/belgif-rest-problem-java-ee-client/src/test/java/io/github/belgif/rest/problem/ee/jaxrs/client/ClientProblemObjectMapperContextResolverTest.java
+++ b/belgif-rest-problem-java-ee-client/src/test/java/io/github/belgif/rest/problem/ee/jaxrs/client/ClientProblemObjectMapperContextResolverTest.java
@@ -1,0 +1,55 @@
+package io.github.belgif.rest.problem.ee.jaxrs.client;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.HashMap;
+
+import javax.annotation.Priority;
+import javax.enterprise.inject.Instance;
+import javax.enterprise.inject.spi.CDI;
+import javax.ws.rs.Priorities;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.github.belgif.rest.problem.ee.CdiProblemTypeRegistry;
+import io.github.belgif.rest.problem.registry.ProblemTypeRegistry;
+
+@ExtendWith(MockitoExtension.class)
+class ClientProblemObjectMapperContextResolverTest {
+
+    @Mock
+    private CdiProblemTypeRegistry registry;
+
+    @Mock
+    private CDI cdi;
+
+    @Mock
+    private Instance instance;
+
+    @Test
+    void mapper() {
+        try (MockedStatic<CDI> mock = mockStatic(CDI.class)) {
+            mock.when(CDI::current).thenReturn(cdi);
+            when(cdi.select(ProblemTypeRegistry.class)).thenReturn(instance);
+            when(instance.get()).thenReturn(registry);
+            when(registry.getProblemTypes()).thenReturn(new HashMap<>());
+            ObjectMapper mapper = new ClientProblemObjectMapperContextResolver().getContext(null);
+            assertThat(mapper.getRegisteredModuleIds()).contains("io.github.belgif.rest.problem.ee.CdiProblemModule");
+        }
+    }
+
+    @Test
+    void canBeOverridden() {
+        assertThat(ClientProblemObjectMapperContextResolver.class).hasAnnotation(Priority.class);
+        assertThat(ClientProblemObjectMapperContextResolver.class.getAnnotation(Priority.class).value())
+                .isGreaterThan(Priorities.USER);
+    }
+
+}

--- a/belgif-rest-problem-java-ee-client/src/test/java/io/github/belgif/rest/problem/ee/jaxrs/client/ProblemClientBuilderTest.java
+++ b/belgif-rest-problem-java-ee-client/src/test/java/io/github/belgif/rest/problem/ee/jaxrs/client/ProblemClientBuilderTest.java
@@ -41,11 +41,13 @@ class ProblemClientBuilderTest {
         Configuration configuration = mock(Configuration.class);
         when(client.getConfiguration()).thenReturn(configuration);
         when(configuration.isRegistered(ProblemClientResponseFilter.class)).thenReturn(false);
+        when(configuration.isRegistered(ClientProblemObjectMapperContextResolver.class)).thenReturn(false);
         Client result = builder.build();
         assertThat(result).isInstanceOf(Client.class);
         assertThat(Proxy.isProxyClass(result.getClass())).isTrue();
         assertThat(Proxy.getInvocationHandler(result)).isInstanceOf(ClientInvocationHandler.class);
         verify(client).register(ProblemClientResponseFilter.class);
+        verify(client).register(ClientProblemObjectMapperContextResolver.class);
     }
 
     @Test
@@ -55,6 +57,7 @@ class ProblemClientBuilderTest {
         Configuration configuration = mock(Configuration.class);
         when(client.getConfiguration()).thenReturn(configuration);
         when(configuration.isRegistered(ProblemClientResponseFilter.class)).thenReturn(true);
+        when(configuration.isRegistered(ClientProblemObjectMapperContextResolver.class)).thenReturn(true);
         Client result = builder.build();
         assertThat(result).isInstanceOf(Client.class);
         assertThat(Proxy.isProxyClass(result.getClass())).isTrue();

--- a/belgif-rest-problem-java-ee-client/src/test/java/io/github/belgif/rest/problem/ee/jaxrs/client/ProblemClientResponseFilterTest.java
+++ b/belgif-rest-problem-java-ee-client/src/test/java/io/github/belgif/rest/problem/ee/jaxrs/client/ProblemClientResponseFilterTest.java
@@ -5,18 +5,23 @@ import static org.mockito.Mockito.*;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.util.function.Supplier;
 
+import javax.enterprise.inject.Instance;
 import javax.ws.rs.client.ClientRequestContext;
 import javax.ws.rs.client.ClientResponseContext;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.ext.Providers;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -24,6 +29,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.belgif.rest.problem.BadRequestProblem;
 import io.github.belgif.rest.problem.DefaultProblem;
 import io.github.belgif.rest.problem.api.Problem;
+import io.github.belgif.rest.problem.ee.jaxrs.JaxRsUtil;
 import io.github.belgif.rest.problem.ee.jaxrs.ProblemMediaType;
 
 @ExtendWith(MockitoExtension.class)
@@ -37,6 +43,12 @@ class ProblemClientResponseFilterTest {
 
     @Mock
     private ClientResponseContext responseContext;
+
+    @Mock
+    private Providers providers;
+
+    @Mock
+    private Instance<ObjectMapper> cdiObjectMapper;
 
     @Mock
     private ObjectMapper objectMapper;
@@ -105,6 +117,22 @@ class ProblemClientResponseFilterTest {
         assertThatNoException().isThrownBy(
                 () -> filter.filter(requestContext, responseContext));
         verifyNoMoreInteractions(requestContext, responseContext);
+    }
+
+    @Test
+    void init() throws Exception {
+        Field objectMapperField = ProblemClientResponseFilter.class.getDeclaredField("objectMapper");
+        objectMapperField.setAccessible(true);
+        objectMapperField.set(filter, null);
+        ObjectMapper newMapper = new ObjectMapper();
+        try (MockedStatic<JaxRsUtil> mock = mockStatic(JaxRsUtil.class)) {
+            mock.when(() -> JaxRsUtil.locateObjectMapper(eq(providers), eq(cdiObjectMapper), eq(Problem.class),
+                    eq(MediaType.APPLICATION_JSON_TYPE), any(Supplier.class))).thenReturn(newMapper);
+            filter.init();
+        }
+        assertThat(filter).hasFieldOrPropertyWithValue("objectMapper", newMapper);
+        filter.init();
+        assertThat(filter).hasFieldOrPropertyWithValue("objectMapper", newMapper);
     }
 
 }

--- a/belgif-rest-problem-java-ee-client/src/test/java/io/github/belgif/rest/problem/ee/jaxrs/client/ProblemRestClientListenerTest.java
+++ b/belgif-rest-problem-java-ee-client/src/test/java/io/github/belgif/rest/problem/ee/jaxrs/client/ProblemRestClientListenerTest.java
@@ -2,13 +2,16 @@ package io.github.belgif.rest.problem.ee.jaxrs.client;
 
 import static org.mockito.Mockito.*;
 
+import javax.ws.rs.core.Configuration;
+
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import io.github.belgif.rest.problem.ee.jaxrs.client.ProblemRestClientListener.ClientProblemObjectMapperContextResolver;
+import io.github.belgif.rest.problem.ee.util.Platform;
 
 @ExtendWith(MockitoExtension.class)
 class ProblemRestClientListenerTest {
@@ -16,11 +19,35 @@ class ProblemRestClientListenerTest {
     @Mock
     private RestClientBuilder restClientBuilder;
 
+    @Mock
+    private Configuration configuration;
+
     @Test
     void listener() {
+        when(restClientBuilder.getConfiguration()).thenReturn(configuration);
         new ProblemRestClientListener().onNewClient(null, restClientBuilder);
-        verify(restClientBuilder).register(ClientProblemObjectMapperContextResolver.class);
         verify(restClientBuilder).register(ProblemResponseExceptionMapper.class);
+        verify(restClientBuilder).register(ClientProblemObjectMapperContextResolver.class);
+    }
+
+    @Test
+    void alreadyRegistered() {
+        when(restClientBuilder.getConfiguration()).thenReturn(configuration);
+        when(configuration.isRegistered(ProblemResponseExceptionMapper.class)).thenReturn(true);
+        when(configuration.isRegistered(ClientProblemObjectMapperContextResolver.class)).thenReturn(true);
+        new ProblemRestClientListener().onNewClient(null, restClientBuilder);
+        verifyNoMoreInteractions(restClientBuilder);
+    }
+
+    @Test
+    void quarkus() {
+        try (MockedStatic<Platform> mock = mockStatic(Platform.class)) {
+            mock.when(Platform::isQuarkus).thenReturn(true);
+            when(restClientBuilder.getConfiguration()).thenReturn(configuration);
+            new ProblemRestClientListener().onNewClient(null, restClientBuilder);
+            verify(restClientBuilder).register(ProblemResponseExceptionMapper.class);
+            verifyNoMoreInteractions(restClientBuilder);
+        }
     }
 
 }

--- a/belgif-rest-problem-java-ee-client/src/test/java/io/github/belgif/rest/problem/ee/jaxrs/client/ProblemSupportTest.java
+++ b/belgif-rest-problem-java-ee-client/src/test/java/io/github/belgif/rest/problem/ee/jaxrs/client/ProblemSupportTest.java
@@ -18,10 +18,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import io.github.belgif.rest.problem.BadRequestProblem;
 import io.github.belgif.rest.problem.ee.jaxrs.client.ProblemSupport.ClientInvocationHandler;
+import io.github.belgif.rest.problem.ee.util.Platform;
 
 @ExtendWith(MockitoExtension.class)
 class ProblemSupportTest {
@@ -36,12 +38,14 @@ class ProblemSupportTest {
     void mockConfiguration() {
         when(client.getConfiguration()).thenReturn(configuration);
         when(configuration.isRegistered(ProblemClientResponseFilter.class)).thenReturn(true);
+        when(configuration.isRegistered(ClientProblemObjectMapperContextResolver.class)).thenReturn(true);
     }
 
     @Test
     void registerProblemClientResponseFilter() {
         reset(configuration);
         when(configuration.isRegistered(ProblemClientResponseFilter.class)).thenReturn(false);
+        when(configuration.isRegistered(ClientProblemObjectMapperContextResolver.class)).thenReturn(false);
         Client result = ProblemSupport.enable(client);
         assertThat(Proxy.isProxyClass(result.getClass())).isTrue();
         assertThat(Proxy.getInvocationHandler(result)).isInstanceOf(ClientInvocationHandler.class);
@@ -61,6 +65,7 @@ class ProblemSupportTest {
                 .isThrownBy(() -> result.target("https://www.belgif.be").request().buildGet().invoke());
 
         verify(client).register(ProblemClientResponseFilter.class);
+        verify(client).register(ClientProblemObjectMapperContextResolver.class);
     }
 
     @Test
@@ -238,6 +243,19 @@ class ProblemSupportTest {
                         .target("https://www.belgif.be")
                         .register("test")
                         .request().buildGet().invoke());
+    }
+
+    @Test
+    void quarkus() {
+        try (MockedStatic<Platform> mock = mockStatic(Platform.class)) {
+            mock.when(Platform::isQuarkus).thenReturn(true);
+            reset(configuration);
+            when(configuration.isRegistered(ProblemClientResponseFilter.class)).thenReturn(false);
+            ProblemSupport.enable(client);
+            verify(client).getConfiguration();
+            verify(client).register(ProblemClientResponseFilter.class);
+            verifyNoMoreInteractions(client);
+        }
     }
 
 }

--- a/belgif-rest-problem-java-ee-client/src/test/java/io/github/belgif/rest/problem/ee/resteasy/client/ResteasyProblemSupportTest.java
+++ b/belgif-rest-problem-java-ee-client/src/test/java/io/github/belgif/rest/problem/ee/resteasy/client/ResteasyProblemSupportTest.java
@@ -12,11 +12,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import io.github.belgif.rest.problem.BadGatewayProblem;
+import io.github.belgif.rest.problem.ee.jaxrs.client.ClientProblemObjectMapperContextResolver;
 import io.github.belgif.rest.problem.ee.jaxrs.client.ProblemClientResponseFilter;
 import io.github.belgif.rest.problem.ee.jaxrs.client.ProblemWrapper;
+import io.github.belgif.rest.problem.ee.util.Platform;
 
 @ExtendWith(MockitoExtension.class)
 class ResteasyProblemSupportTest {
@@ -24,7 +27,7 @@ class ResteasyProblemSupportTest {
     @Mock
     private ResteasyWebTarget target;
 
-    @Mock
+    @Mock(strictness = Mock.Strictness.LENIENT)
     private Configuration configuration;
 
     @Mock
@@ -38,11 +41,13 @@ class ResteasyProblemSupportTest {
     void mockConfiguration() {
         when(target.getConfiguration()).thenReturn(configuration);
         when(configuration.isRegistered(ProblemClientResponseFilter.class)).thenReturn(true);
+        when(configuration.isRegistered(ClientProblemObjectMapperContextResolver.class)).thenReturn(true);
     }
 
     @Test
     void proxy() {
         when(configuration.isRegistered(ProblemClientResponseFilter.class)).thenReturn(false);
+        when(configuration.isRegistered(ClientProblemObjectMapperContextResolver.class)).thenReturn(false);
         when(target.proxy(Service.class)).thenReturn(serviceMock);
         Service service = ResteasyProblemSupport.proxy(target, Service.class);
 
@@ -51,6 +56,25 @@ class ResteasyProblemSupportTest {
                 .isInstanceOf(ResteasyProblemSupport.ProxyInvocationHandler.class);
 
         verify(target).register(ProblemClientResponseFilter.class);
+        verify(target).register(ClientProblemObjectMapperContextResolver.class);
+    }
+
+    @Test
+    void quarkus() {
+        when(configuration.isRegistered(ProblemClientResponseFilter.class)).thenReturn(false);
+        when(configuration.isRegistered(ClientProblemObjectMapperContextResolver.class)).thenReturn(false);
+        when(target.proxy(Service.class)).thenReturn(serviceMock);
+        try (MockedStatic<Platform> mock = mockStatic(Platform.class)) {
+            mock.when(Platform::isQuarkus).thenReturn(true);
+            Service service = ResteasyProblemSupport.proxy(target, Service.class);
+
+            assertThat(Proxy.isProxyClass(service.getClass())).isTrue();
+            assertThat(Proxy.getInvocationHandler(service))
+                    .isInstanceOf(ResteasyProblemSupport.ProxyInvocationHandler.class);
+
+            verify(target).register(ProblemClientResponseFilter.class);
+            verifyNoMoreInteractions(target);
+        }
     }
 
     @Test

--- a/belgif-rest-problem-java-ee-core/src/main/java/io/github/belgif/rest/problem/ee/jaxrs/JaxRsUtil.java
+++ b/belgif-rest-problem-java-ee-core/src/main/java/io/github/belgif/rest/problem/ee/jaxrs/JaxRsUtil.java
@@ -1,0 +1,93 @@
+package io.github.belgif.rest.problem.ee.jaxrs;
+
+import java.util.function.Supplier;
+
+import javax.enterprise.inject.Instance;
+import javax.enterprise.inject.spi.CDI;
+import javax.ws.rs.core.Configurable;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.ext.ContextResolver;
+import javax.ws.rs.ext.Providers;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Utility class for JAX-RS components.
+ */
+public class JaxRsUtil {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(JaxRsUtil.class);
+
+    private JaxRsUtil() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    /**
+     * Register the given component class on the given Configurable (only if no yet registered).
+     *
+     * @param configurable the {@link Configurable}
+     * @param componentClass the component class
+     */
+    public static void register(Configurable<?> configurable, Class<?> componentClass) {
+        if (!configurable.getConfiguration().isRegistered(componentClass)) {
+            configurable.register(componentClass);
+        }
+    }
+
+    /**
+     * Locate the Jackson ObjectMapper from the runtime platform, in the following order of precedence:
+     * <ul>
+     * <li>from JAX-RS {@code ContextResolver<ObjectMapper>}</li>
+     * <li>from CDI {@code @Inject Instance<ObjectMapper>}</li>
+     * <li>from static CDI.current()</li>
+     * <li>fallback to the supplied default</li>
+     * </ul>
+     *
+     * @param providers the JAX-RS Providers
+     * @param cdiObjectMapper the {@code @Inject Instance<ObjectMapper>}
+     * @param entityClass the entity class
+     * @param mediaType the media type
+     * @param fallback the ObjectMapper supplier to use as fallback
+     * @return the ObjectMapper
+     */
+    public static ObjectMapper locateObjectMapper(Providers providers, Instance<ObjectMapper> cdiObjectMapper,
+            Class<?> entityClass, MediaType mediaType, Supplier<ObjectMapper> fallback) {
+        // First, try the JAX-RS providers
+        if (providers != null) {
+            ContextResolver<ObjectMapper> resolver =
+                    providers.getContextResolver(ObjectMapper.class, mediaType);
+            if (resolver != null) {
+                ObjectMapper result = resolver.getContext(entityClass);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        // Then, try the CDI ObjectMapper
+        if (cdiObjectMapper != null && cdiObjectMapper.isResolvable()) {
+            ObjectMapper result = cdiObjectMapper.get();
+            if (result != null) {
+                return result;
+            }
+        }
+        // Then, try static CDI access
+        try {
+            Instance<ObjectMapper> instance = CDI.current().select(ObjectMapper.class);
+            if (instance != null && instance.isResolvable()) {
+                ObjectMapper result = instance.get();
+                if (result != null) {
+                    return result;
+                }
+            }
+        } catch (IllegalStateException e) {
+            // CDI is not available
+        }
+        LOGGER.warn("ObjectMapper could not be retrieved from CDI or JAX-RS context, falling back to default");
+        // Use fallback as last resort
+        return fallback.get();
+    }
+
+}

--- a/belgif-rest-problem-java-ee-core/src/main/java/io/github/belgif/rest/problem/ee/jaxrs/ProblemObjectMapperContextResolver.java
+++ b/belgif-rest-problem-java-ee-core/src/main/java/io/github/belgif/rest/problem/ee/jaxrs/ProblemObjectMapperContextResolver.java
@@ -7,6 +7,9 @@ import javax.ws.rs.ext.Provider;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+/**
+ * ContextResolver for ProblemObjectMapper.
+ */
 @Provider
 @Priority(Priorities.USER + 200)
 public class ProblemObjectMapperContextResolver implements ContextResolver<ObjectMapper> {

--- a/belgif-rest-problem-java-ee-core/src/main/java/io/github/belgif/rest/problem/ee/util/Platform.java
+++ b/belgif-rest-problem-java-ee-core/src/main/java/io/github/belgif/rest/problem/ee/util/Platform.java
@@ -1,0 +1,27 @@
+package io.github.belgif.rest.problem.ee.util;
+
+/**
+ * Utility class to detect the runtime platform.
+ */
+public class Platform {
+
+    private static final boolean IS_QUARKUS = detectClass("io.quarkus.runtime.Quarkus");
+
+    private Platform() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    public static boolean isQuarkus() {
+        return IS_QUARKUS;
+    }
+
+    private static boolean detectClass(String clazz) {
+        try {
+            Class.forName(clazz);
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+
+}

--- a/belgif-rest-problem-java-ee-core/src/main/java/io/github/belgif/rest/problem/ee/util/Platform.java
+++ b/belgif-rest-problem-java-ee-core/src/main/java/io/github/belgif/rest/problem/ee/util/Platform.java
@@ -15,7 +15,7 @@ public class Platform {
         return IS_QUARKUS;
     }
 
-    private static boolean detectClass(String clazz) {
+    static boolean detectClass(String clazz) {
         try {
             Class.forName(clazz);
             return true;

--- a/belgif-rest-problem-java-ee-core/src/test/java/io/github/belgif/rest/problem/ee/jaxrs/JaxRsUtilTest.java
+++ b/belgif-rest-problem-java-ee-core/src/test/java/io/github/belgif/rest/problem/ee/jaxrs/JaxRsUtilTest.java
@@ -57,6 +57,32 @@ class JaxRsUtilTest {
     }
 
     @Test
+    void locateObjectMapperFromProvidersNullContextResolver() {
+        Providers providers = mock(Providers.class);
+        when(providers.getContextResolver(ObjectMapper.class, MediaType.APPLICATION_JSON_TYPE))
+                .thenReturn(null);
+
+        ObjectMapper mapper = new ObjectMapper();
+        ObjectMapper result = JaxRsUtil.locateObjectMapper(providers, null, Problem.class,
+                MediaType.APPLICATION_JSON_TYPE, () -> mapper);
+        assertThat(result).isSameAs(mapper);
+    }
+
+    @Test
+    void locateObjectMapperFromProvidersNullObjectMapper() {
+        Providers providers = mock(Providers.class);
+        ContextResolver<ObjectMapper> contextResolver = mock(ContextResolver.class);
+        when(providers.getContextResolver(ObjectMapper.class, MediaType.APPLICATION_JSON_TYPE))
+                .thenReturn(contextResolver);
+        when(contextResolver.getContext(Problem.class)).thenReturn(null);
+
+        ObjectMapper mapper = new ObjectMapper();
+        ObjectMapper result = JaxRsUtil.locateObjectMapper(providers, null, Problem.class,
+                MediaType.APPLICATION_JSON_TYPE, () -> mapper);
+        assertThat(result).isSameAs(mapper);
+    }
+
+    @Test
     void locateObjectMapperFromCdiInstance() {
         Instance<ObjectMapper> cdiObjectMapper = mock(Instance.class);
         ObjectMapper mapper = new ObjectMapper();
@@ -65,6 +91,29 @@ class JaxRsUtilTest {
 
         ObjectMapper result = JaxRsUtil.locateObjectMapper(null, cdiObjectMapper, Problem.class,
                 MediaType.APPLICATION_JSON_TYPE, null);
+        assertThat(result).isSameAs(mapper);
+    }
+
+    @Test
+    void locateObjectMapperFromCdiInstanceNotResolvable() {
+        Instance<ObjectMapper> cdiObjectMapper = mock(Instance.class);
+        when(cdiObjectMapper.isResolvable()).thenReturn(false);
+
+        ObjectMapper mapper = new ObjectMapper();
+        ObjectMapper result = JaxRsUtil.locateObjectMapper(null, cdiObjectMapper, Problem.class,
+                MediaType.APPLICATION_JSON_TYPE, () -> mapper);
+        assertThat(result).isSameAs(mapper);
+    }
+
+    @Test
+    void locateObjectMapperFromCdiInstanceNullObjectMapper() {
+        Instance<ObjectMapper> cdiObjectMapper = mock(Instance.class);
+        when(cdiObjectMapper.isResolvable()).thenReturn(true);
+        when(cdiObjectMapper.get()).thenReturn(null);
+
+        ObjectMapper mapper = new ObjectMapper();
+        ObjectMapper result = JaxRsUtil.locateObjectMapper(null, cdiObjectMapper, Problem.class,
+                MediaType.APPLICATION_JSON_TYPE, () -> mapper);
         assertThat(result).isSameAs(mapper);
     }
 
@@ -80,6 +129,61 @@ class JaxRsUtilTest {
             when(cdiObjectMapper.get()).thenReturn(mapper);
             ObjectMapper result = JaxRsUtil.locateObjectMapper(null, null, Problem.class,
                     MediaType.APPLICATION_JSON_TYPE, null);
+            assertThat(result).isSameAs(mapper);
+        }
+    }
+
+    @Test
+    void locateObjectMapperFromCdiStaticIllegalStateException() {
+        try (MockedStatic<CDI> mock = mockStatic(CDI.class)) {
+            mock.when(CDI::current).thenThrow(new IllegalStateException("CDI not available"));
+            ObjectMapper mapper = new ObjectMapper();
+            ObjectMapper result = JaxRsUtil.locateObjectMapper(null, null, Problem.class,
+                    MediaType.APPLICATION_JSON_TYPE, () -> mapper);
+            assertThat(result).isSameAs(mapper);
+        }
+    }
+
+    @Test
+    void locateObjectMapperFromCdiStaticNullInstance() {
+        CDI cdi = mock(CDI.class);
+        try (MockedStatic<CDI> mock = mockStatic(CDI.class)) {
+            mock.when(CDI::current).thenReturn(cdi);
+            when(cdi.select(ObjectMapper.class)).thenReturn(null);
+            ObjectMapper mapper = new ObjectMapper();
+            ObjectMapper result = JaxRsUtil.locateObjectMapper(null, null, Problem.class,
+                    MediaType.APPLICATION_JSON_TYPE, () -> mapper);
+            assertThat(result).isSameAs(mapper);
+        }
+    }
+
+    @Test
+    void locateObjectMapperFromCdiStaticNotResolvable() {
+        CDI cdi = mock(CDI.class);
+        Instance<ObjectMapper> cdiObjectMapper = mock(Instance.class);
+        try (MockedStatic<CDI> mock = mockStatic(CDI.class)) {
+            mock.when(CDI::current).thenReturn(cdi);
+            when(cdi.select(ObjectMapper.class)).thenReturn(cdiObjectMapper);
+            when(cdiObjectMapper.isResolvable()).thenReturn(false);
+            ObjectMapper mapper = new ObjectMapper();
+            ObjectMapper result = JaxRsUtil.locateObjectMapper(null, null, Problem.class,
+                    MediaType.APPLICATION_JSON_TYPE, () -> mapper);
+            assertThat(result).isSameAs(mapper);
+        }
+    }
+
+    @Test
+    void locateObjectMapperFromCdiStaticNullObjectMapper() {
+        CDI cdi = mock(CDI.class);
+        Instance<ObjectMapper> cdiObjectMapper = mock(Instance.class);
+        try (MockedStatic<CDI> mock = mockStatic(CDI.class)) {
+            mock.when(CDI::current).thenReturn(cdi);
+            when(cdi.select(ObjectMapper.class)).thenReturn(cdiObjectMapper);
+            when(cdiObjectMapper.isResolvable()).thenReturn(true);
+            when(cdiObjectMapper.get()).thenReturn(null);
+            ObjectMapper mapper = new ObjectMapper();
+            ObjectMapper result = JaxRsUtil.locateObjectMapper(null, null, Problem.class,
+                    MediaType.APPLICATION_JSON_TYPE, () -> mapper);
             assertThat(result).isSameAs(mapper);
         }
     }

--- a/belgif-rest-problem-java-ee-core/src/test/java/io/github/belgif/rest/problem/ee/jaxrs/JaxRsUtilTest.java
+++ b/belgif-rest-problem-java-ee-core/src/test/java/io/github/belgif/rest/problem/ee/jaxrs/JaxRsUtilTest.java
@@ -1,0 +1,95 @@
+package io.github.belgif.rest.problem.ee.jaxrs;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import javax.enterprise.inject.Instance;
+import javax.enterprise.inject.spi.CDI;
+import javax.ws.rs.core.Configurable;
+import javax.ws.rs.core.Configuration;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.ext.ContextResolver;
+import javax.ws.rs.ext.Providers;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.github.belgif.rest.problem.api.Problem;
+
+class JaxRsUtilTest {
+
+    @Test
+    void register() {
+        Configurable configurable = mock(Configurable.class);
+        Configuration configuration = mock(Configuration.class);
+        when(configurable.getConfiguration()).thenReturn(configuration);
+        Class<?> componentClass = JaxRsUtilTest.class;
+        when(configuration.isRegistered(componentClass)).thenReturn(false);
+        JaxRsUtil.register(configurable, componentClass);
+        verify(configurable).register(componentClass);
+    }
+
+    @Test
+    void registerAlreadyRegistered() {
+        Configurable configurable = mock(Configurable.class);
+        Configuration configuration = mock(Configuration.class);
+        when(configurable.getConfiguration()).thenReturn(configuration);
+        Class<?> componentClass = JaxRsUtilTest.class;
+        when(configuration.isRegistered(componentClass)).thenReturn(true);
+        JaxRsUtil.register(configurable, componentClass);
+        verify(configurable, never()).register(componentClass);
+    }
+
+    @Test
+    void locateObjectMapperFromProviders() {
+        Providers providers = mock(Providers.class);
+        ContextResolver<ObjectMapper> contextResolver = mock(ContextResolver.class);
+        ObjectMapper mapper = new ObjectMapper();
+        when(providers.getContextResolver(ObjectMapper.class, MediaType.APPLICATION_JSON_TYPE))
+                .thenReturn(contextResolver);
+        when(contextResolver.getContext(Problem.class)).thenReturn(mapper);
+
+        ObjectMapper result = JaxRsUtil.locateObjectMapper(providers, null, Problem.class,
+                MediaType.APPLICATION_JSON_TYPE, null);
+        assertThat(result).isSameAs(mapper);
+    }
+
+    @Test
+    void locateObjectMapperFromCdiInstance() {
+        Instance<ObjectMapper> cdiObjectMapper = mock(Instance.class);
+        ObjectMapper mapper = new ObjectMapper();
+        when(cdiObjectMapper.isResolvable()).thenReturn(true);
+        when(cdiObjectMapper.get()).thenReturn(mapper);
+
+        ObjectMapper result = JaxRsUtil.locateObjectMapper(null, cdiObjectMapper, Problem.class,
+                MediaType.APPLICATION_JSON_TYPE, null);
+        assertThat(result).isSameAs(mapper);
+    }
+
+    @Test
+    void locateObjectMapperFromCdiStatic() {
+        CDI cdi = mock(CDI.class);
+        Instance<ObjectMapper> cdiObjectMapper = mock(Instance.class);
+        try (MockedStatic<CDI> mock = mockStatic(CDI.class)) {
+            mock.when(CDI::current).thenReturn(cdi);
+            when(cdi.select(ObjectMapper.class)).thenReturn(cdiObjectMapper);
+            ObjectMapper mapper = new ObjectMapper();
+            when(cdiObjectMapper.isResolvable()).thenReturn(true);
+            when(cdiObjectMapper.get()).thenReturn(mapper);
+            ObjectMapper result = JaxRsUtil.locateObjectMapper(null, null, Problem.class,
+                    MediaType.APPLICATION_JSON_TYPE, null);
+            assertThat(result).isSameAs(mapper);
+        }
+    }
+
+    @Test
+    void locateObjectMapperFallback() {
+        ObjectMapper mapper = new ObjectMapper();
+        ObjectMapper result = JaxRsUtil.locateObjectMapper(null, null, Problem.class,
+                MediaType.APPLICATION_JSON_TYPE, () -> mapper);
+        assertThat(result).isSameAs(mapper);
+    }
+
+}

--- a/belgif-rest-problem-java-ee-core/src/test/java/io/github/belgif/rest/problem/ee/util/PlatformTest.java
+++ b/belgif-rest-problem-java-ee-core/src/test/java/io/github/belgif/rest/problem/ee/util/PlatformTest.java
@@ -1,0 +1,15 @@
+package io.github.belgif.rest.problem.ee.util;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+
+import org.junit.jupiter.api.Test;
+
+class PlatformTest {
+
+    @Test
+    void detectClass() {
+        assertThat(Platform.detectClass("java.lang.String")).isTrue();
+        assertThat(Platform.detectClass("not.Found")).isFalse();
+    }
+
+}

--- a/belgif-rest-problem-quarkus-client-deployment/pom.xml
+++ b/belgif-rest-problem-quarkus-client-deployment/pom.xml
@@ -32,7 +32,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-rest-jackson-common-deployment</artifactId>
+      <artifactId>quarkus-jackson-deployment</artifactId>
     </dependency>
     <dependency>
       <groupId>io.github.belgif.rest.problem</groupId>

--- a/belgif-rest-problem-quarkus-client-deployment/src/main/java/io/github/belgif/rest/problem/quarkus/deployment/client/ProblemExtensionClientProcessor.java
+++ b/belgif-rest-problem-quarkus-client-deployment/src/main/java/io/github/belgif/rest/problem/quarkus/deployment/client/ProblemExtensionClientProcessor.java
@@ -11,7 +11,6 @@ import jakarta.ws.rs.client.WebTarget;
 
 import org.eclipse.microprofile.rest.client.spi.RestClientListener;
 
-import io.github.belgif.rest.problem.ee.jaxrs.ProblemObjectMapperContextResolver;
 import io.github.belgif.rest.problem.ee.jaxrs.client.ProblemClientResponseFilter;
 import io.github.belgif.rest.problem.ee.jaxrs.client.ProblemResponseExceptionMapper;
 import io.github.belgif.rest.problem.ee.jaxrs.client.ProblemRestClientListener;
@@ -54,8 +53,6 @@ public class ProblemExtensionClientProcessor {
     ReflectiveClassBuildItem registerRestClientListenerForReflection() {
         return ReflectiveClassBuildItem.builder(
                 ProblemRestClientListener.class.getName(),
-                ProblemRestClientListener.ClientProblemObjectMapperContextResolver.class.getName(),
-                ProblemObjectMapperContextResolver.class.getName(),
                 ProblemResponseExceptionMapper.class.getName(),
                 ProblemClientResponseFilter.class.getName())
                 .constructors().methods().fields()

--- a/belgif-rest-problem-quarkus-client-deployment/src/test/java/io/github/belgif/rest/problem/quarkus/deployment/client/ProblemExtensionClientProcessorTest.java
+++ b/belgif-rest-problem-quarkus-client-deployment/src/test/java/io/github/belgif/rest/problem/quarkus/deployment/client/ProblemExtensionClientProcessorTest.java
@@ -13,7 +13,6 @@ import jakarta.ws.rs.client.WebTarget;
 
 import org.junit.jupiter.api.Test;
 
-import io.github.belgif.rest.problem.ee.jaxrs.ProblemObjectMapperContextResolver;
 import io.github.belgif.rest.problem.ee.jaxrs.client.ProblemClientResponseFilter;
 import io.github.belgif.rest.problem.ee.jaxrs.client.ProblemResponseExceptionMapper;
 import io.github.belgif.rest.problem.ee.jaxrs.client.ProblemRestClientListener;
@@ -55,8 +54,6 @@ class ProblemExtensionClientProcessorTest {
         ReflectiveClassBuildItem result = processor.registerRestClientListenerForReflection();
         assertThat(result.getClassNames()).containsExactly(
                 ProblemRestClientListener.class.getName(),
-                ProblemRestClientListener.ClientProblemObjectMapperContextResolver.class.getName(),
-                ProblemObjectMapperContextResolver.class.getName(),
                 ProblemResponseExceptionMapper.class.getName(),
                 ProblemClientResponseFilter.class.getName());
         assertThat(result.isConstructors()).isTrue();

--- a/belgif-rest-problem-quarkus-client/pom.xml
+++ b/belgif-rest-problem-quarkus-client/pom.xml
@@ -79,12 +79,12 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5-mockito</artifactId>
+      <artifactId>quarkus-junit-mockito</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/belgif-rest-problem-quarkus-client/pom.xml
+++ b/belgif-rest-problem-quarkus-client/pom.xml
@@ -50,7 +50,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-rest-jackson-common</artifactId>
+      <artifactId>quarkus-jackson</artifactId>
     </dependency>
     <dependency>
       <groupId>jakarta.enterprise</groupId>

--- a/belgif-rest-problem-quarkus-core-deployment/pom.xml
+++ b/belgif-rest-problem-quarkus-core-deployment/pom.xml
@@ -32,7 +32,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-rest-jackson-common-deployment</artifactId>
+      <artifactId>quarkus-jackson-deployment</artifactId>
     </dependency>
     <dependency>
       <groupId>io.github.belgif.rest.problem</groupId>

--- a/belgif-rest-problem-quarkus-core/pom.xml
+++ b/belgif-rest-problem-quarkus-core/pom.xml
@@ -32,6 +32,12 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>io.github.belgif.rest.problem</groupId>
+      <artifactId>belgif-rest-problem-jakarta-ee-core</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-rest-jackson-common</artifactId>
     </dependency>
@@ -99,6 +105,7 @@
                     META-INF/MANIFEST.MF,
                     META-INF/services/jakarta.enterprise.inject.spi.Extension,
                     io/github/belgif/rest/problem/ee/jaxrs/ProblemConfigurator.class,
+                    io/github/belgif/rest/problem/ee/jaxrs/ProblemObjectMapperContextResolver.class,
                     io/github/belgif/rest/problem/ee/registry/CdiProblemTypeRegistry.class
                   </excludes>
                 </artifactItem>

--- a/belgif-rest-problem-quarkus-core/pom.xml
+++ b/belgif-rest-problem-quarkus-core/pom.xml
@@ -68,12 +68,12 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5-mockito</artifactId>
+      <artifactId>quarkus-junit-mockito</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/belgif-rest-problem-quarkus-core/pom.xml
+++ b/belgif-rest-problem-quarkus-core/pom.xml
@@ -39,7 +39,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-rest-jackson-common</artifactId>
+      <artifactId>quarkus-jackson</artifactId>
     </dependency>
     <dependency>
       <groupId>jakarta.enterprise</groupId>

--- a/belgif-rest-problem-quarkus-core/src/main/java/io/github/belgif/rest/problem/quarkus/core/ProblemObjectMapperCustomizer.java
+++ b/belgif-rest-problem-quarkus-core/src/main/java/io/github/belgif/rest/problem/quarkus/core/ProblemObjectMapperCustomizer.java
@@ -1,0 +1,21 @@
+package io.github.belgif.rest.problem.quarkus.core;
+
+import jakarta.inject.Singleton;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.github.belgif.rest.problem.ee.CdiProblemModule;
+import io.quarkus.jackson.ObjectMapperCustomizer;
+
+/**
+ * ObjectMapperCustomizer that registers the CdiProblemModule.
+ */
+@Singleton
+public class ProblemObjectMapperCustomizer implements ObjectMapperCustomizer {
+
+    @Override
+    public void customize(ObjectMapper objectMapper) {
+        objectMapper.registerModule(new CdiProblemModule());
+    }
+
+}

--- a/belgif-rest-problem-quarkus-core/src/test/java/io/github/belgif/rest/problem/quarkus/core/ProblemObjectMapperCustomizerTest.java
+++ b/belgif-rest-problem-quarkus-core/src/test/java/io/github/belgif/rest/problem/quarkus/core/ProblemObjectMapperCustomizerTest.java
@@ -1,0 +1,51 @@
+package io.github.belgif.rest.problem.quarkus.core;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.HashMap;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.spi.CDI;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.github.belgif.rest.problem.ee.CdiProblemTypeRegistry;
+import io.github.belgif.rest.problem.registry.ProblemTypeRegistry;
+
+@ExtendWith(MockitoExtension.class)
+class ProblemObjectMapperCustomizerTest {
+
+    private final ProblemObjectMapperCustomizer customizer = new ProblemObjectMapperCustomizer();
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock
+    private CdiProblemTypeRegistry registry;
+
+    @Mock
+    private CDI cdi;
+
+    @Mock
+    private Instance instance;
+
+    @Test
+    void customize() {
+        try (MockedStatic<CDI> mock = mockStatic(CDI.class)) {
+            mock.when(CDI::current).thenReturn(cdi);
+            when(cdi.select(ProblemTypeRegistry.class)).thenReturn(instance);
+            when(instance.get()).thenReturn(registry);
+            when(registry.getProblemTypes()).thenReturn(new HashMap<>());
+            customizer.customize(objectMapper);
+            assertThat(objectMapper.getRegisteredModuleIds())
+                    .containsExactly("io.github.belgif.rest.problem.ee.CdiProblemModule");
+        }
+    }
+
+}

--- a/belgif-rest-problem-quarkus-server-deployment/pom.xml
+++ b/belgif-rest-problem-quarkus-server-deployment/pom.xml
@@ -32,7 +32,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-rest-jackson-common-deployment</artifactId>
+      <artifactId>quarkus-jackson-deployment</artifactId>
     </dependency>
     <dependency>
       <groupId>io.github.belgif.rest.problem</groupId>

--- a/belgif-rest-problem-quarkus-server/pom.xml
+++ b/belgif-rest-problem-quarkus-server/pom.xml
@@ -68,12 +68,12 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5-mockito</artifactId>
+      <artifactId>quarkus-junit-mockito</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/belgif-rest-problem-quarkus-server/pom.xml
+++ b/belgif-rest-problem-quarkus-server/pom.xml
@@ -39,7 +39,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-rest-jackson-common</artifactId>
+      <artifactId>quarkus-jackson</artifactId>
     </dependency>
     <dependency>
       <groupId>jakarta.enterprise</groupId>

--- a/belgif-rest-problem/pom.xml
+++ b/belgif-rest-problem/pom.xml
@@ -89,6 +89,17 @@
             </goals>
             <configuration>
               <indexVersion>11</indexVersion>
+              <fileSets>
+                <fileSet>
+                  <directory>${project.build.outputDirectory}</directory>
+                  <!-- Exclude Jackson3 components from Jandex index, as they result in warnings on Quarkus -->
+                  <excludes>
+                    <exclude>io/github/belgif/rest/problem/ProblemModuleJackson3.class</exclude>
+                    <exclude>io/github/belgif/rest/problem/ProblemModuleJackson3$*.class</exclude>
+                    <exclude>io/github/belgif/rest/problem/internal/Jackson3Util.class</exclude>
+                  </excludes>
+                </fileSet>
+              </fileSets>
             </configuration>
           </execution>
         </executions>

--- a/belgif-rest-problem/pom.xml
+++ b/belgif-rest-problem/pom.xml
@@ -88,7 +88,7 @@
               <goal>jandex</goal>
             </goals>
             <configuration>
-              <indexVersion>10</indexVersion>
+              <indexVersion>11</indexVersion>
             </configuration>
           </execution>
         </executions>

--- a/src/main/asciidoc/release-notes.adoc
+++ b/src/main/asciidoc/release-notes.adoc
@@ -18,6 +18,10 @@
 
 * Fix `@ConditionalOnClass`  loading of optional components
 
+*belgif-rest-problem-quarkus-core:*
+
+* Replace Jakarta EE ContextResolver<ObjectMapper> by Quarkus ProblemObjectMapperCustomizer
+
 == Version 0.21
 
 *belgif-rest-problem:*

--- a/src/main/asciidoc/release-notes.adoc
+++ b/src/main/asciidoc/release-notes.adoc
@@ -18,9 +18,15 @@
 
 * Fix `@ConditionalOnClass`  loading of optional components
 
-*belgif-rest-problem-quarkus-core:*
+*belgif-rest-problem-quarkus:*
 
 * Replace Jakarta EE ContextResolver<ObjectMapper> by Quarkus ProblemObjectMapperCustomizer
+
+*belgif-rest-problem-java-ee:*
+
+* Modify ProblemClientResponseFilter to obtain the ObjectMapper from the underlying JAX-RS or CDI runtime, instead of hardcoded ProblemObjectMapper instance
+* Don't register ClientProblemObjectMapperContextResolver on Quarkus
+* Prevent duplicate registrations of same JAX-RS component
 
 == Version 0.21
 

--- a/src/main/asciidoc/release-notes.adoc
+++ b/src/main/asciidoc/release-notes.adoc
@@ -25,6 +25,7 @@
 *belgif-rest-problem-quarkus:*
 
 * Replace Jakarta EE ContextResolver<ObjectMapper> by Quarkus ProblemObjectMapperCustomizer
+* Replace quarkus-rest-jackson-common dependency by quarkus-jackson
 
 *belgif-rest-problem-java-ee:*
 

--- a/src/main/asciidoc/release-notes.adoc
+++ b/src/main/asciidoc/release-notes.adoc
@@ -14,7 +14,11 @@
 
 == Version 0.22
 
-*belgif-rest-problem-spring-boot-**:
+*belgif-rest-problem*:
+
+* Bump bundled jandex indexVersion from 10 to 11. This prevents warnings on Quarkus, but may result in warnings on JBoss EAP 7.4 (https://access.redhat.com/articles/2332721[end-of-support]).
+
+*belgif-rest-problem-spring-boot*:
 
 * Fix `@ConditionalOnClass`  loading of optional components
 


### PR DESCRIPTION
* Replace Jakarta EE ContextResolver<ObjectMapper> by Quarkus ProblemObjectMapperCustomizer
* Modify ProblemClientResponseFilter to obtain the ObjectMapper from the underlying JAX-RS or CDI runtime, instead of hardcoded ProblemObjectMapper instance
* Don't register ClientProblemObjectMapperContextResolver on Quarkus
* Prevent duplicate registrations of same JAX-RS component
* Replace quarkus-rest-jackson-common dependency by quarkus-jackson
* Bump jandex indexVersion from 10 to 11