### PR TITLE
Prevent auto-merge of broken dependabot PRs

### DIFF
--- a/.github/workflows/maven-ci-build.yml
+++ b/.github/workflows/maven-ci-build.yml
@@ -3,12 +3,9 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
   workflow_dispatch:
 jobs:
   build:
-    # skip if triggered by a "labeled" event with a label other than "publish-snapshot"
-    if: github.event_name != 'pull_request' || github.event.action != 'labeled' || github.event.label.name == 'publish-snapshot'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6


### PR DESCRIPTION
Fix #324.

Remove logic to trigger build when a "publish-snapshot" label gets added to a PR, because it results in dependabot PRs sometimes being auto-merged without a successful build.

The problem is that "skipped" github actions are considered successful for required branch protection checks.

So PRs where another label gets added (e.g. "dependencies") can get merged without an actual successful build.

This does mean that an (empty) commit should be pushed after assigning "publish-snapshot" label to trigger a new build.